### PR TITLE
Fix MUX toggling issue 

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -505,6 +505,12 @@ void LinkManagerStateMachine::handleStateChange(MuxStateEvent &event, mux_state:
     if (ms(mCompositeState) != mux_state::MuxState::Wait) {
         // Verify if state db MUX state matches the driver/current MUX state
         mMuxPortPtr->getMuxState();
+
+        // Handle pening mux mode config change
+        if (mPendingMuxModeChange) {
+            handleMuxConfigNotification(mTargetMuxMode);
+            mPendingMuxModeChange = false;
+        }
     }
 
     if (ms(mCompositeState) != mux_state::MuxState::Unknown) {
@@ -706,28 +712,41 @@ void LinkManagerStateMachine::handleSwssLinkStateNotification(const link_state::
 //
 void LinkManagerStateMachine::handleMuxConfigNotification(const common::MuxPortConfig::Mode mode)
 {
-    if (mComponentInitState.all()) {
-        if (mode == common::MuxPortConfig::Mode::Active &&
-            ms(mCompositeState) != mux_state::MuxState::Label::Active &&
-            ms(mCompositeState) != mux_state::MuxState::Label::Wait) {
-            CompositeState nextState = mCompositeState;
-            enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
-            switchMuxState(nextState, mux_state::MuxState::Label::Active);
-            LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
-            mCompositeState = nextState;
-        } else if(mode == common::MuxPortConfig::Mode::Standby &&
-                  ms(mCompositeState) != mux_state::MuxState::Label::Standby &&
-                  ms(mCompositeState) != mux_state::MuxState::Label::Wait) {
-            mSendPeerSwitchCommandFnPtr();
-        } else {
-            mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
-            mMuxPortPtr->probeMuxState();
+    if (mComponentInitState.test(MuxStateComponent) &&
+        mode != common::MuxPortConfig::Mode::Auto && 
+        mode != common::MuxPortConfig::Mode::Manual &&
+        ms(mCompositeState) == mux_state::MuxState::Wait) {
+        
+        MUXLOGWARNING(boost::format("%s: Mux mode: %s , mux mode config change is pending. ") % 
+                mMuxPortConfig.getPortName() %
+                mMuxStateName[ms(mCompositeState)]
+            );
+
+        mPendingMuxModeChange = true;
+        mTargetMuxMode = mode;
+    } else {
+        if (mComponentInitState.all()) {
+            if (mode == common::MuxPortConfig::Mode::Active &&
+                    ms(mCompositeState) != mux_state::MuxState::Label::Active) {
+                CompositeState nextState = mCompositeState;
+                enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
+                switchMuxState(nextState, mux_state::MuxState::Label::Active);
+                LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+                mCompositeState = nextState;
+            } else if(mode == common::MuxPortConfig::Mode::Standby &&
+                        ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
+                mSendPeerSwitchCommandFnPtr();
+            } else {
+                mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
+                mMuxPortPtr->probeMuxState();
+            }
+
+            updateMuxLinkmgrState();
         }
 
-        updateMuxLinkmgrState();
-    }
+        mMuxPortConfig.setMode(mode);
 
-    mMuxPortConfig.setMode(mode);
+    }
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -919,6 +919,9 @@ private:
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
 
+    bool mPendingMuxModeChange = false;
+    common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;
+
     std::bitset<ComponentCount> mComponentInitState = {0};
     Label mLabel = Label::Uninitialized;
 };

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -53,6 +53,9 @@ public:
     mux_state::MuxStateMachine& getMuxStateMachine() {return getLinkManagerStateMachine()->getMuxStateMachine();};
     link_state::LinkStateMachine& getLinkStateMachine() {return getLinkManagerStateMachine()->getLinkStateMachine();};
 
+    bool getPendingMuxModeChange() {return getLinkManagerStateMachine()->mPendingMuxModeChange;};
+    common::MuxPortConfig::Mode getTargetMuxMode() {return getLinkManagerStateMachine()->mTargetMuxMode;};
+
     std::shared_ptr<FakeLinkProber> mFakeLinkProber;
 };
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix the issue that randomly fails MUX state toggling. 

To be more specific, the issue was when trying to toggle MUX ports from standby to active utilizing cli  "config mux mode standby all", some random ports won't be toggled successfully and will remain standby mode. This issue can be easily reproduced when ICMP_responder is off but not when the ports are in healthy state. 

The cause is when ICMP_responder is off and ToRs stay in unhealthy state, linkmgrd will probe mux state every 300ms[^1]  which will make mux state enter "wait". While mux state equals "wait", linkmgrd won't switch mux sate to user's desiring state[^2]. 

A state machine diagram for this particular scenario can be found under the internal sharepoint folder for Gemini design doc.  

[^1]: This interval will be multiplied by a backoff factor if the returned state is unknown. 
[^2]: Instead, it will do a mux state probe. 

Signed-off-by: Jing Zhang <zhangjing@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?

We want to make sure users are able to toggle from standby to active even when icmp responder is not working, without manual retries.  

#### How did you do it?

Cache the MUX mode configuration change, execute the change once MUX exits "wait" state. 

#### How did you verify/test it?

Tested it on virtual dual testbeds, unable to reproduce the issue anymore. 


