### PR TITLE
Fix unstable unit tests (state change handler wasn't invoked)

### DIFF
--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -54,17 +54,17 @@ LinkManagerStateMachineTest::LinkManagerStateMachineTest() :
 void LinkManagerStateMachineTest::runIoService(uint32_t count)
 {
     if (count == 0) {
-        mIoService.run();
         if(mIoService.stopped()) {
             mIoService.reset();
         }
+        mIoService.run();
     }
 
     for (uint8_t i = 0; i < count; i++) {
-        mIoService.run_one();
         if(mIoService.stopped()) {
             mIoService.reset();            
         }
+        mIoService.run_one();
     }
 }
 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -66,6 +66,8 @@ void LinkManagerStateMachineTest::runIoService(uint32_t count)
         }
         mIoService.run_one();
     }
+
+    mIoService.reset();
 }
 
 void LinkManagerStateMachineTest::postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count)

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -55,12 +55,16 @@ void LinkManagerStateMachineTest::runIoService(uint32_t count)
 {
     if (count == 0) {
         mIoService.run();
-        mIoService.reset();
+        if(mIoService.stopped()) {
+            mIoService.reset();
+        }
     }
 
     for (uint8_t i = 0; i < count; i++) {
         mIoService.run_one();
-        mIoService.reset();
+        if(mIoService.stopped()) {
+            mIoService.reset();            
+        }
     }
 }
 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -55,19 +55,17 @@ void LinkManagerStateMachineTest::runIoService(uint32_t count)
 {
     if (count == 0) {
         if(mIoService.stopped()) {
-            mIoService.reset();
+            mIoService.restart();
         }
         mIoService.run();
     }
 
     for (uint8_t i = 0; i < count; i++) {
         if(mIoService.stopped()) {
-            mIoService.reset();            
+            mIoService.restart();            
         }
         mIoService.run_one();
     }
-
-    mIoService.reset();
 }
 
 void LinkManagerStateMachineTest::postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue) 

Fix unstable unit tests.

People observed that linkmgrd unit tests appeared to be flaky, and kept failing PR checks. After checking the build logs, I found that in most of the failures, the state change handler didn't seem to be invoked: Linkmgrd's composite state remained as it was before the state change was post. 

This PR updates code to invoke io_service::reset(), sets the io_service to no longer be in a stopped state, allowing subsequent calls to run_one() to invoke handlers. (When io_service is stopped, any call to run_one() will return immediately without invoking any handler. ) 

Signed-off-by: Jing Zhang <zhangjing@microsoft.com>

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Stabilize linkmgrd unit tests. 

#### How did you do it?
Reset stopped io_service before calling to run_one(), to guarantee state change handlers are invoked as expected. 

#### How did you verify/test it?
Tested building locally.
 
This issue is hard to reproduce, the current build failure data is 48 times in the last 30 days. We should expect to see improvement after this change. 



