### PR TITLE
[unittest] Add missing intermediate states

### DIFF
--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -757,6 +757,8 @@ TEST_F(LinkManagerStateMachineTest, StandbyStateToProberUnknownMuxUnknownLinkUp)
     VALIDATE_STATE(Standby, Wait, Up);
 
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    VALIDATE_STATE(Unknown, Wait, Up);
+
     handleProbeMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
@@ -776,7 +778,10 @@ TEST_F(LinkManagerStateMachineTest, StandbyStateToProberUnknownMuxUnknownLinkUp)
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 
     // swss notification
-    handleMuxState("unknown", 4);
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Wait, Unknown, Up);
+
+    runIoService(2);
     VALIDATE_STATE(Wait, Wait, Up);
 
     postLinkProberEvent(link_prober::LinkProberState::Active, 2);
@@ -801,7 +806,10 @@ TEST_F(LinkManagerStateMachineTest, ProberUnknownMuxUnknownLinkDown)
     handleMuxState("unknown", 4);
     VALIDATE_STATE(Active, Unknown, Down);
 
-    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    VALIDATE_STATE(Unknown, Unknown, Down);
+
+    runIoService(2);
     VALIDATE_STATE(Unknown, Wait, Down);
 
     handleProbeMuxState("unknown", 4);
@@ -839,7 +847,10 @@ TEST_F(LinkManagerStateMachineTest, ProberWaitMuxUnknownLinkDown)
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 
     // swss notification
-    handleMuxState("unknown", 4);
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Wait, Unknown, Up);
+
+    runIoService(2);
     VALIDATE_STATE(Wait, Wait, Up);
 
     handleLinkState("down", 3);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [x] Unit test

### Approach
#### What is the motivation for this PR?
For those mux unknown states change tests, once the link manager state machine enters states like `(unknown, unknown, up/down)` or `(wait, unknown, up/down)`, after `mDeadlineTimer` timeouts, the state machine will enter intermediate states with mux state as `wait`.

#### How did you do it?
Cover the state changes to those intermediate states:
* `(unknown, unknown, up/down)` ---> `(unknown, wait, up/down)`
* `(wait, unknown, up/down)` ---> `(wait, wait, up/down)`

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->