### PR TITLE
[linkmgrd] linkmgrd subscribes MUX_CABLE_INFO table to handle peer OIR events

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -643,7 +643,7 @@ void DbInterface::handleLinkStateNotifiction(swss::SubscriberStateTable &appdbPo
 //
 // process peer's link state notification 
 // 
-void processPeerLinkStateNotification(std::deque<swss:KeyOpFieldsValuesTuple> &entries)
+void DbInterface::processPeerLinkStateNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries)
 {
     for (auto &entry: entries) {
         std::string port = kfvKey(entry);
@@ -677,7 +677,7 @@ void processPeerLinkStateNotification(std::deque<swss:KeyOpFieldsValuesTuple> &e
 //
 void DbInterface::handlePeerLinkStateNotification(swss::SubscriberStateTable &stateDbMuxInfoTable)
 {
-    std::deque<swss:KeyOpFieldsValuesTuple> entries;
+    std::deque<swss::KeyOpFieldsValuesTuple> entries;
 
     stateDbMuxInfoTable.pops(entries);
     processPeerLinkStateNotification(entries);

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -853,7 +853,7 @@ void DbInterface::handleSwssNotification()
     // for getting state db default route state 
     swss::SubscriberStateTable stateDbRouteTable(stateDbPtr.get(), STATE_ROUTE_TABLE_NAME);
     // for getting peer's link status
-    swss::SubscriberStateTable stateDbMuxInfoTable(stateDbPtr.get(), "MUX_CABLE_INFO");
+    swss::SubscriberStateTable stateDbMuxInfoTable(stateDbPtr.get(), MUX_CABLE_INFO_TABLE);
 
     getTorMacAddress(configDbPtr);
     getLoopback2InterfaceInfo(configDbPtr);

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -484,6 +484,28 @@ private:
     */
     void handleSwssNotification();
 
+    /**
+     * @method processDefaultRouteStateNotification
+     * 
+     * @brief process default route state notification from orchagent
+     * 
+     * @param entries reference to state db default route state entries
+     * 
+     * @return none
+    */
+    void processDefaultRouteStateNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
+    /**
+     * @method handleDefaultRouteStateNotification
+     * 
+     * @brief handle Default Route State notification from orchagent
+     * 
+     * @param statedbRouteTable reference to state db route table 
+     * 
+     * @return none
+    */
+    void handleDefaultRouteStateNotification(swss::SubscriberStateTable &statedbRouteTable);
+
 private:
     static std::vector<std::string> mMuxState;
     static std::vector<std::string> mMuxLinkmgrState;

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -418,7 +418,7 @@ private:
      * 
      * @return none
     */
-    inline void processPeerLinkStateNotification(std::deque<swss:KeyOpFieldsValuesTuple> &entries);
+    inline void processPeerLinkStateNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
 
     /**
      * @method handlePeerLinkStateNotification

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -410,6 +410,28 @@ private:
     void handleLinkStateNotifiction(swss::SubscriberStateTable &appdbPortTable);
 
     /**
+     * @method processPeerLinkStateNotification
+     * 
+     * @brief process peer link status change notification
+     * 
+     * @param entries reference to state db mux cable info table 
+     * 
+     * @return none
+    */
+    inline void processPeerLinkStateNotification(std::deque<swss:KeyOpFieldsValuesTuple> &entries);
+
+    /**
+     * @method handlePeerLinkStateNotification
+     * 
+     * @brief handle peer's link status change notification 
+     * 
+     * @param stateDbMuxInfoTable reference to state db mux info table 
+     * 
+     * @return none
+    */
+    void handlePeerLinkStateNotification(swss::SubscriberStateTable &stateDbMuxInfoTable);
+
+    /**
     *@method processMuxResponseNotifiction
     *
     *@brief process MUX response (from xcvrd) notification

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -44,6 +44,8 @@ class MuxManagerTest;
 
 namespace mux
 {
+#define MUX_CABLE_INFO_TABLE  "MUX_CABLE_INFO"
+
 class MuxManager;
 using ServerIpPortMap = std::map<boost::asio::ip::address, std::string>;
 

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -163,7 +163,7 @@ void MuxManager::updateMuxPortConfig(const std::string &portName, const std::str
 //
 // ---> addOrUpdateMuxPortLinkState(const std::string &portName, const std::string &linkState);
 //
-// update MUX port server/blade IPv4 Address. If port is not found, create new MuxPort object
+// update MUX port link state. If port is not found, create new MuxPort object
 //
 void MuxManager::addOrUpdateMuxPortLinkState(const std::string &portName, const std::string &linkState)
 {
@@ -171,6 +171,19 @@ void MuxManager::addOrUpdateMuxPortLinkState(const std::string &portName, const 
 
     std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
     muxPortPtr->handleLinkState(linkState);
+}
+
+// 
+// ---> addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState);
+// 
+// update mux port's peer link state. If port is not found, create new MuxPort object.
+//
+void addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState)
+{
+    MUXLOGWARNING(boost::format("%s: peer link state %s") % portName % linkState);
+
+    std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
+    muxPortPtr->handlePeerLinkState(linkState);
 }
 
 //

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -178,7 +178,7 @@ void MuxManager::addOrUpdateMuxPortLinkState(const std::string &portName, const 
 // 
 // update mux port's peer link state. If port is not found, create new MuxPort object.
 //
-void addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState)
+void MuxManager::addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState)
 {
     MUXLOGWARNING(boost::format("%s: peer link state %s") % portName % linkState);
 

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -248,6 +248,34 @@ void MuxManager::processProbeMuxState(const std::string &portName, const std::st
 }
 
 //
+// ---> addOrUpdateDefaultRouteState(boost::asio::ip::address& address, const std::string &routeState);
+//
+// update default route state based on state db notification
+//
+void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &routeState) 
+{
+    if (is_v4) {
+        mIpv4DefaultRouteState = routeState;
+    } else {
+        mIpv6DefaultRouteState = routeState;
+    }
+
+    std::string nextState = "na";
+    // For now we only need IPv4 default route state to be "ok". If we switch to IPv6 in the furture, this will cause an issue. 
+    if (mIpv4DefaultRouteState == "ok") {
+        nextState = "ok";
+    }
+
+    MUXLOGINFO(boost::format("Default route state: %s") % nextState);
+
+    PortMapIterator portMapIterator = mPortMap.begin();
+    while (portMapIterator != mPortMap.end()) {
+        portMapIterator->second->handleDefaultRouteState(nextState);
+        portMapIterator ++;
+    }
+}
+
+//
 // ---> getMuxPortPtrOrThrow(const std::string &portName);
 //
 // retrieve a pointer to MuxPort if it exist or create a new MuxPort object

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -317,6 +317,19 @@ public:
     */
     void processProbeMuxState(const std::string &portName, const std::string &muxState);
 
+    /**
+     * @method addOrUpdateDefaultRouteState
+     * 
+     * @brief update default route state based on state db notification
+     * 
+     * @param ipAddress
+     * @param routeState
+     *  
+     * @return none
+     * 
+    */
+    void addOrUpdateDefaultRouteState(bool is_v4, const std::string &routeState);
+
 private:
     /**
     *@method getMuxPortPtrOrThrow
@@ -372,6 +385,9 @@ private:
     std::shared_ptr<mux::DbInterface> mDbInterfacePtr;
 
     PortMap mPortMap;
+
+    std::string mIpv4DefaultRouteState = "na";
+    std::string mIpv6DefaultRouteState = "na";
 };
 
 } /* namespace mux */

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -248,7 +248,7 @@ public:
     /**
     *@method addOrUpdateMuxPortLinkState
     *
-    *@brief update MUX port server/blade IPv4 Address. If port is not found, create new MuxPort object
+    *@brief update MUX port link state. If port is not found, create new MuxPort object
     *
     *@param portName (in)   Mux port name
     *@param linkState (in)  Mux port link state
@@ -256,6 +256,18 @@ public:
     *@return none
     */
     void addOrUpdateMuxPortLinkState(const std::string &portName, const std::string &linkState);
+
+    /**
+     * @method addOrUpdatePeerLinkState
+     * 
+     * @brief update mux port's peer link state. If port is not found, create new MuxPort object.
+     * 
+     * @param portName (in) Mux port name
+     * @param linkState (in) Peer's link state
+     * 
+     * @return none
+    */
+    void addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState);
 
     /**
     *@method addOrUpdateMuxPortMuxState

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -250,4 +250,20 @@ void MuxPort::handleMuxConfig(const std::string &config)
     )));
 }
 
+// 
+// ---> handleDefaultRouteState(const std::string &routeState);
+// 
+// handles default route state notification
+//
+void MuxPort::handleDefaultRouteState(const std::string &routeState)
+{
+    MUXLOGDEBUG(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachine::handleDefaultRouteStateNotification,
+        &mLinkManagerStateMachine,
+        routeState
+    )));
+}
 } /* namespace mux */

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -110,6 +110,28 @@ void MuxPort::handleLinkState(const std::string &linkState)
 }
 
 //
+// ---> handlePeerLinkState(const std::string &linkState); 
+//
+// handle peer's link state updates
+//
+void MuxPort::handlePeerLinkState(const std::string &linkState)
+{
+    MUXLOGDEBUG(boost::format("port: %s, state db peer link state: %s") % mMuxPortConfig.getPortName() % linkState);
+
+    link_state::LinkState::Label label = link_state::LinkState::Label::Down;
+    if (linkState == "up") {
+        label = link_state::LinkState::Label::Up;
+    }
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachine::handlePeerLinkStateNotification,
+        &mLinkManagerStateMachine,
+        label
+    )));
+}
+
+//
 // ---> handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address)
 //
 // handles get Server MAC address

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -118,9 +118,9 @@ void MuxPort::handlePeerLinkState(const std::string &linkState)
 {
     MUXLOGDEBUG(boost::format("port: %s, state db peer link state: %s") % mMuxPortConfig.getPortName() % linkState);
 
-    link_state::LinkState::Label label = link_state::LinkState::Label::Down;
-    if (linkState == "up") {
-        label = link_state::LinkState::Label::Up;
+    link_state::LinkState::Label label = link_state::LinkState::Label::Up;
+    if (linkState == "down") {
+        label = link_state::LinkState::Label::Down;
     }
 
     boost::asio::io_service &ioService = mStrand.context();

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -198,6 +198,17 @@ public:
     void handleLinkState(const std::string &linkState);
 
     /**
+     * @method handlePeerLinkState
+     * 
+     * @brief handles peer's link state updates 
+     * 
+     * @param linkState (in) peer's link state
+     * 
+     * @return none 
+    */
+    void handlePeerLinkState(const std::string &linkState);
+
+    /**
     *@method handleGetServerMacAddress
     *
     *@brief handles get Server MAC address

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -263,6 +263,17 @@ public:
     */
     void handleMuxConfig(const std::string &config);
 
+    /**
+     * @method handleDefaultRouteState(const std::string &routeState)
+     * 
+     * @brief handles default route state notification
+     * 
+     * @param routeState 
+     * 
+     * @return none
+    */
+    void handleDefaultRouteState(const std::string &routeState);
+
 protected:
     friend class test::MuxManagerTest;
     friend class test::FakeMuxPort;

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -833,6 +833,28 @@ void LinkManagerStateMachine::handleSwitchActiveRequestEvent()
     }
 }
 
+// 
+// ---> handleDefaultRouteStateNotification(const std::string &routeState);
+// 
+// handle default route state notification from routeorch
+//
+void LinkManagerStateMachine::handleDefaultRouteStateNotification(const std::string &routeState)
+{
+    MUXLOGWARNING(boost::format("%s: state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+
+    if (mComponentInitState.test(MuxStateComponent)) {
+        if (ms(mCompositeState) != mux_state::MuxState::Label::Standby && routeState == "na") {
+            CompositeState nextState = mCompositeState;
+            enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+            LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+            mCompositeState = nextState;
+        } else {
+            enterMuxWaitState(mCompositeState);
+        }
+    } 
+}
+
 //
 // ---> updateMuxLinkmgrState();
 //

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -710,6 +710,24 @@ void LinkManagerStateMachine::handleSwssLinkStateNotification(const link_state::
     }
 }
 
+// ---> handlePeerLinkStateNotification(const link_state::LinkState::Label label);
+// 
+// handle peer link state change notification 
+//
+void handlePeerLinkStateNotification(const link_state::LinkState::Label label)
+{
+    MUXLOGINFO(boost::format("%s: state db peer link state: %s") % mMuxPortConfig.getPortName() % mLinkStateName[label]);
+
+    mPeerLinkState = label;
+    if(label == link_state::LinkState::Label::Down && ms(mCompositeState) == mux_state::MuxState::Standby) {
+        CompositeState nextState = mCompositeState;
+        enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
+        switchMuxState(nextState, mux_state::MuxState::Label::Active);
+        LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+        mCompositeState = nextState;
+    }
+}
+
 //
 // ---> handleMuxConfigNotification(const common::MuxPortConfig::Mode mode);
 //

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -714,7 +714,7 @@ void LinkManagerStateMachine::handleSwssLinkStateNotification(const link_state::
 // 
 // handle peer link state change notification 
 //
-void handlePeerLinkStateNotification(const link_state::LinkState::Label label)
+void LinkManagerStateMachine::handlePeerLinkStateNotification(const link_state::LinkState::Label label)
 {
     MUXLOGINFO(boost::format("%s: state db peer link state: %s") % mMuxPortConfig.getPortName() % mLinkStateName[label]);
 

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -437,6 +437,17 @@ public:
     *@return none
     */
     void handleSwssLinkStateNotification(const link_state::LinkState::Label label);
+    
+    /**
+     * @method handlePeerLinkStateNotification
+     * 
+     * @brief handle peer link state notification
+     * 
+     * @param label (in) new peer link state label
+     * 
+     * @return none
+    */
+    void handlePeerLinkStateNotification(const link_state::LinkState::Label label);
 
     /**
     *@method handleMuxConfigNotification
@@ -904,6 +915,8 @@ private:
     std::shared_ptr<link_prober::LinkProber> mLinkProberPtr = nullptr;
     mux_state::MuxStateMachine mMuxStateMachine;
     link_state::LinkStateMachine mLinkStateMachine;
+
+    link_state::LinkState::Label mPeerLinkState = link_state::LinkState::Label::Down;
 
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -487,6 +487,17 @@ public:
     */
     void handleSwitchActiveRequestEvent();
 
+    /**
+     * @method handleDefaultRouteStateNotification(const std::string &routeState)
+     * 
+     * @brief handle default route state notification from routeorch
+     * 
+     * @param routeState
+     * 
+     * @return none
+    */
+    void handleDefaultRouteStateNotification(const std::string &routeState);
+
 private:
     /**
     *@method updateMuxLinkmgrState

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -230,6 +230,12 @@ void LinkManagerStateMachineTest::setMuxStandby()
     VALIDATE_STATE(Standby, Standby, Up);
 }
 
+void LinkManagerStateMachineTest::postDefaultRouteEvent(std::string routeState, uint32_t count)
+{
+    mFakeMuxPort.handleDefaultRouteState(routeState);
+    runIoService(count);
+}
+
 TEST_F(LinkManagerStateMachineTest, MuxActiveSwitchOver)
 {
     setMuxActive();
@@ -1011,6 +1017,40 @@ TEST_F(LinkManagerStateMachineTest, MuxStandby2Unknown2Error)
 
     handleMuxState("error", 3);
     VALIDATE_STATE(Standby, Error, Down);
+}
+
+TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA) 
+{
+    setMuxActive();
+
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    postDefaultRouteEvent("na", 3);
+
+    VALIDATE_STATE(Wait, Wait, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+
+    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Standby, Standby, Up);
+}
+
+TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 
+{
+    setMuxStandby();
+
+    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 0);
+    postDefaultRouteEvent("ok", 2);
+
+    VALIDATE_STATE(Standby, Wait, Up);
+    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 1);
+
+    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Standby, Standby, Up);
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -52,6 +52,7 @@ public:
     void setMuxActive();
     void setMuxStandby();
     void postDefaultRouteEvent(std::string routeState, uint32_t count = 0);
+    void postPeerLinkStateEvent(std::string linkState, uint32_t count = 0);
 
 public:
     boost::asio::io_service mIoService;

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -51,6 +51,7 @@ public:
     void activateStateMachine();
     void setMuxActive();
     void setMuxStandby();
+    void postDefaultRouteEvent(std::string routeState, uint32_t count = 0);
 
 public:
     boost::asio::io_service mIoService;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

In the current Gemini linkmgrd design, when ICMP pinging consistently fails, a link prober unknown event won't trigger a switchover. In this scenario, if active side's cable is unplugged, there won't be a toggle to switch standby side to active. This PR is to handle this edge case.  

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To make sure switchover happens when active side's cable is unplugged even when ICMP is not working. 

#### How did you do it?
Make linkmgrd listen to MUX_CABLE_INFO table, which stores peer's link status. This peer's link status will be probed and updated through I2C from MUX every 60s. 

#### How did you verify/test it?
Added Unit tests. Also tested this change on dual testbed, toggling happened as expected. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->