### PR TITLE
[db_interface] Use new config db cable and link prober config table names

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -577,7 +577,7 @@ void DbInterface::processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTupl
 void DbInterface::getServerIpAddress(std::shared_ptr<swss::DBConnector> configDbConnector)
 {
     MUXLOGINFO("Reading MUX Server IPs");
-    swss::Table configDbMuxCableTable(configDbConnector.get(), CFG_MUX_CABLE_TABLE_NAME);
+    swss::Table configDbMuxCableTable(configDbConnector.get(), CFG_LINKMGR_CABLE_TABLE_NAME);
     std::vector<swss::KeyOpFieldsValuesTuple> entries;
 
     configDbMuxCableTable.getContent(entries);
@@ -971,9 +971,9 @@ void DbInterface::handleSwssNotification()
     std::shared_ptr<swss::DBConnector> stateDbPtr = std::make_shared<swss::DBConnector> ("STATE_DB", 0);
 
     // For reading Link Prober configurations from the MUX linkmgr table name
-    swss::SubscriberStateTable configDbMuxLinkmgrTable(configDbPtr.get(), CFG_MUX_LINKMGR_TABLE_NAME);
+    swss::SubscriberStateTable configDbMuxLinkmgrTable(configDbPtr.get(), CFG_LINKMGR_TABLE_NAME);
 
-    swss::SubscriberStateTable configDbMuxTable(configDbPtr.get(), CFG_MUX_CABLE_TABLE_NAME);
+    swss::SubscriberStateTable configDbMuxTable(configDbPtr.get(), CFG_LINKMGR_CABLE_TABLE_NAME);
 
     // for link up/down, should be in state db down the road
     swss::SubscriberStateTable appDbPortTable(appDbPtr.get(), APP_PORT_TABLE_NAME);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Use the new config db cable and link prober config table names introduced by PR: https://github.com/Azure/sonic-swss-common/pull/580

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Let `db_interface` listen to new db table names for key events.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->