### PR TITLE
Handle xcvrd crashing scenarios

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -61,7 +61,7 @@
 namespace link_manager
 {
 
-constexpr auto MAX_BACKOFF_FACTOR = 8;
+constexpr auto MAX_BACKOFF_FACTOR = 32;
 
 LinkManagerStateMachine::TransitionFunction
     LinkManagerStateMachine::mStateTransitionHandler[link_prober::LinkProberState::Label::Count]

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -859,6 +859,7 @@ void LinkManagerStateMachine::handleDefaultRouteStateNotification(const std::str
     if (mComponentInitState.test(MuxStateComponent)) {
         if (ms(mCompositeState) != mux_state::MuxState::Label::Standby && routeState == "na") {
             mSendPeerSwitchCommandFnPtr();
+            // In case Mux is in wait state, switchMuxSate(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established.
             mMuxPortPtr->setMuxState(mux_state::MuxState::Label::Standby);
         } else {
             enterMuxWaitState(mCompositeState);

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -971,6 +971,7 @@ private:
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
+    uint32_t mMuxWaitTimeoutCount = 0;
 
     bool mPendingMuxModeChange = false;
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -73,7 +73,7 @@ FakeMuxPort::FakeMuxPort(
         boost::bind(&FakeLinkProber::resumeTxProbes, mFakeLinkProber.get())
     );
     getLinkManagerStateMachine()->setSendPeerSwitchCommandFnPtr(
-        boost::bind(&FakeLinkProber::resumeTxProbes, mFakeLinkProber.get())
+        boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
 }
 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1046,8 +1046,11 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
     setMuxActive();
 
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 0);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
     postDefaultRouteEvent("na", 3);
+    
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1045,17 +1045,9 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
 {
     setMuxActive();
 
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 0);
     postDefaultRouteEvent("na", 3);
-
-    VALIDATE_STATE(Wait, Wait, Up);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
-
-    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
-    VALIDATE_STATE(Standby, Wait, Up);
-
-    handleMuxState("standby", 3);
-    VALIDATE_STATE(Standby, Standby, Up);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

XCVRD on a ToR can crash in different scenarios, and currently the expected behaviors are: 
1. Crashing when toggling to Active
   1. Toggle triggered by ```sudo config mux standby``` on peer 
      Expected to succeed. Peer will toggle mux. No action is needed. 
   1. Toggle triggered by ```sudo config mux active```
      Expected to fail. Nothing can be done to help.    
   1. Toggle Triggered by LinkProber: Unknown
      Expected to fail. Nothing can be done to help.  
   1. Toggle Triggered by peer link status down (OIR)
      Expected to fail. Nothing can be done to help.  
   1. linkmgrd mismatching last updated xcvrd state
      Can’t be sure if the last updated state is accurate, if Mux is: 
      a. Pointing to local ToR
            Expected to succeed. 
      b. Pointing to peer ToR
             Expected to fail. Local ToR ends in probing mux state, tunnel won't be created.        
1. Crashing when toggling to Standby
   1. Toggle triggered by LinkState: Down
      Expected to success. Peer will toggle mux. No action is needed. 
   1. Toggle triggered by ```sudo config mux mode standby```
	  Expected to success. Peer will toggle mux. No action is needed. 
   1. Toggle triggered by ```sudo config mux mode active``` on peer
      Expected to fail. Local ToR ends in probing mux state, tunnel won't be created. 
   1. Toggle triggered by default route state change
      Expected to fail. 
   1. linkmgrd mismatching last updated xcvrd state
      Can’t be sure if the last updated state is accurate, if Mux is: 
      a. Pointing to local ToR
            Expected to fail. Local ToR ends in probing mux state, tunnel won't be created.
      b. Pointing to peer ToR
             Expected to succeed.        
1. Crashing when probing mux state
	Probing is trigger by state changes, or state inconsistency. To guarantee the tunnel is created, better to toggle local ToR to standby in this case. 
1. Crashing in normal scenarios
    No action is needed. 


There is nothing we can do to help Case 1.ii, 1.iii, and 1.iv. 

This PR is to make local ToR toggle to standby in failure case  1.v.b, 2.iii, 2.iv, 2.v.a and 3.  

This fix relies on ICMP heartbeat. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To make dual ToR still functional in most XCVRD crashing cases. 

#### How did you do it?
Send switch to active command to peer through ICMP. Set mux cable table in app db so orchagent can establish the tunnel. 

#### How did you verify/test it?
Tested on virtual testbed with ICMP_responder on and pmon off, peer successfully toggled to active in the case mentioned above. 


#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->