### PR TITLE
Update log level for mux probing and mux state chance

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -324,8 +324,8 @@ void DbInterface::handleSetMuxState(const std::string portName, mux_state::MuxSt
 //
 void DbInterface::handleProbeMuxState(const std::string portName)
 {
-    MUXLOGDEBUG(portName);
-
+    MUXLOGWARNING(boost::format("%s: trigger xcvrd to read Mux State using i2c. ") % portName);
+    
     mAppDbMuxCommandTablePtr->hset(portName, "command", "probe");
 }
 

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -325,7 +325,7 @@ void DbInterface::handleSetMuxState(const std::string portName, mux_state::MuxSt
 void DbInterface::handleProbeMuxState(const std::string portName)
 {
     MUXLOGWARNING(boost::format("%s: trigger xcvrd to read Mux State using i2c. ") % portName);
-    
+
     mAppDbMuxCommandTablePtr->hset(portName, "command", "probe");
 }
 

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -502,7 +502,7 @@ void LinkManagerStateMachine::handleStateChange(LinkProberEvent &event, link_pro
 void LinkManagerStateMachine::handleStateChange(MuxStateEvent &event, mux_state::MuxState::Label state)
 {
     if ((dynamic_cast<mux_state::MuxState *> (mMuxStateMachine.getCurrentState()))->getStateLabel() == state) {
-        MUXLOGINFO(boost::format("%s: Received mux state event, new state: %s") %
+        MUXLOGWARNING(boost::format("%s: Received mux state event, new state: %s") %
             mMuxPortConfig.getPortName() %
             mMuxStateName[state]
         );
@@ -632,7 +632,7 @@ void LinkManagerStateMachine::handleGetMuxStateNotification(mux_state::MuxState:
 //
 void LinkManagerStateMachine::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGINFO(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    MUXLOGWARNING(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mWaitTimer.cancel();
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Currently mux probing's log level is info (linkmgrd's default level is warning), this makes debugging harder, as to trigger mux state probing is a very important move of linkmgrd's state transition logic. 

We also don't have mux state change logging in warning level. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To have important log in default logging level. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->