### PR TITLE
Add abstract class `LinkManagerStateMachineBase`

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -114,11 +114,11 @@ void DbInterface::probeMuxState(const std::string &portName)
 }
 
 //
-// ---> setMuxLinkmgrState(const std::string &portName, link_manager::LinkManagerStateMachine::Label label);
+// ---> setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label);
 //
 // set MUX LinkMgr state in State DB for cli processing
 //
-void DbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::LinkManagerStateMachine::Label label)
+void DbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label)
 {
     MUXLOGDEBUG(boost::format("%s: setting mux linkmgr to %s") % portName % mMuxLinkmgrState[static_cast<int> (label)]);
 
@@ -134,14 +134,14 @@ void DbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::
 //
 // ---> postMetricsEvent(
 //          const std::string &portName,
-//          link_manager::LinkManagerStateMachine::Metrics metrics
+//          link_manager::ActiveStandbyStateMachine::Metrics metrics
 //          mux_state::MuxState::Label label);
 //
 // post MUX metrics event
 //
 void DbInterface::postMetricsEvent(
     const std::string &portName,
-    link_manager::LinkManagerStateMachine::Metrics metrics,
+    link_manager::ActiveStandbyStateMachine::Metrics metrics,
     mux_state::MuxState::Label label
 )
 {
@@ -165,13 +165,13 @@ void DbInterface::postMetricsEvent(
 // 
 // ---> postLinkProberMetricsEvent(
 //        const std::string &portName, 
-//        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
+//        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics
 //    );
 //
 // post link probe pck loss event to state db 
 void DbInterface::postLinkProberMetricsEvent(
         const std::string &portName, 
-        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
+        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics
 )
 {
     MUXLOGWARNING(boost::format("%s: posting link prober pck loss event %s") %
@@ -330,18 +330,18 @@ void DbInterface::handleProbeMuxState(const std::string portName)
 }
 
 //
-// ---> handleSetMuxLinkmgrState(const std::string portName, link_manager::LinkManagerStateMachine::Label label);
+// ---> handleSetMuxLinkmgrState(const std::string portName, link_manager::ActiveStandbyStateMachine::Label label);
 //
 // set MUX LinkMgr state in State DB for cli processing
 //
 void DbInterface::handleSetMuxLinkmgrState(
     const std::string portName,
-    link_manager::LinkManagerStateMachine::Label label
+    link_manager::ActiveStandbyStateMachine::Label label
 )
 {
     MUXLOGDEBUG(boost::format("%s: setting mux linkmgr state to %s") % portName % mMuxLinkmgrState[static_cast<int> (label)]);
 
-    if (label < link_manager::LinkManagerStateMachine::Label::Count) {
+    if (label < link_manager::ActiveStandbyStateMachine::Label::Count) {
         mStateDbMuxLinkmgrTablePtr->hset(portName, "state", mMuxLinkmgrState[static_cast<int> (label)]);
     }
 }
@@ -349,7 +349,7 @@ void DbInterface::handleSetMuxLinkmgrState(
 //
 // ---> handlePostMuxMetrics(
 //          const std::string portName,
-//          link_manager::LinkManagerStateMachine::Metrics metrics,
+//          link_manager::ActiveStandbyStateMachine::Metrics metrics,
 //          mux_state::MuxState::Label label,
 //          boost::posix_time::ptime time);
 //
@@ -357,7 +357,7 @@ void DbInterface::handleSetMuxLinkmgrState(
 //
 void DbInterface::handlePostMuxMetrics(
     const std::string portName,
-    link_manager::LinkManagerStateMachine::Metrics metrics,
+    link_manager::ActiveStandbyStateMachine::Metrics metrics,
     mux_state::MuxState::Label label,
     boost::posix_time::ptime time
 )
@@ -368,7 +368,7 @@ void DbInterface::handlePostMuxMetrics(
         mMuxMetrics[static_cast<int> (metrics)]
     );
 
-    if (metrics == link_manager::LinkManagerStateMachine::Metrics::SwitchingStart) {
+    if (metrics == link_manager::ActiveStandbyStateMachine::Metrics::SwitchingStart) {
         mStateDbMuxMetricsTablePtr->del(portName);
     }
 
@@ -382,14 +382,14 @@ void DbInterface::handlePostMuxMetrics(
 // 
 // ---> handlePostLinkProberMetrics(
 //        const std::string portName,
-//        link_manager::LinkManagerStateMachine::LinkProberMetrics,
+//        link_manager::ActiveStandbyStateMachine::LinkProberMetrics,
 //        boost::posix_time::ptime time
 //    );
 //
 // post link prober pck loss event to state db 
 void DbInterface::handlePostLinkProberMetrics(
     const std::string portName,
-    link_manager::LinkManagerStateMachine::LinkProberMetrics metrics,
+    link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics,
     boost::posix_time::ptime time
 )
 {
@@ -398,7 +398,7 @@ void DbInterface::handlePostLinkProberMetrics(
         mLinkProbeMetrics[static_cast<int> (metrics)]
     );
 
-    if (metrics == link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberUnknownStart) {
+    if (metrics == link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberUnknownStart) {
         mStateDbLinkProbeStatsTablePtr->hdel(portName, mLinkProbeMetrics[0]);
         mStateDbLinkProbeStatsTablePtr->hdel(portName, mLinkProbeMetrics[1]);
     }

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -154,7 +154,7 @@ public:
     *
     *@return none
     */
-    virtual void setMuxLinkmgrState(const std::string &portName, link_manager::LinkManagerStateMachine::Label label);
+    virtual void setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label);
 
     /**
     *@method postMetricsEvent
@@ -169,7 +169,7 @@ public:
     */
     virtual void postMetricsEvent(
         const std::string &portName,
-        link_manager::LinkManagerStateMachine::Metrics metrics,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
     );
 
@@ -186,7 +186,7 @@ public:
     */
     virtual void postLinkProberMetricsEvent(
         const std::string &portName, 
-        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
+        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics
     );
 
     /**
@@ -292,7 +292,7 @@ private:
     *
     *@return none
     */
-    void handleSetMuxLinkmgrState(const std::string portName, link_manager::LinkManagerStateMachine::Label label);
+    void handleSetMuxLinkmgrState(const std::string portName, link_manager::ActiveStandbyStateMachine::Label label);
 
     /**
     *@method handlePostMuxMetrics
@@ -308,7 +308,7 @@ private:
     */
     void handlePostMuxMetrics(
         const std::string portName,
-        link_manager::LinkManagerStateMachine::Metrics metrics,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label,
         boost::posix_time::ptime time
     );
@@ -326,7 +326,7 @@ private:
     */
     void handlePostLinkProberMetrics(
         const std::string portName,
-        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics,
+        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics,
         boost::posix_time::ptime time
     );
 

--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -108,7 +108,7 @@ int main(int argc, const char* argv[])
 
         // initialize static data
         link_prober::IcmpPayload::generateGuid();
-        link_manager::LinkManagerStateMachine::initializeTransitionFunctionTable();
+        link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
 
         std::shared_ptr<mux::MuxManager> muxManagerPtr = std::make_shared<mux::MuxManager> ();
         muxManagerPtr->initialize();

--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -108,7 +108,6 @@ int main(int argc, const char* argv[])
 
         // initialize static data
         link_prober::IcmpPayload::generateGuid();
-        link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
 
         std::shared_ptr<mux::MuxManager> muxManagerPtr = std::make_shared<mux::MuxManager> ();
         muxManagerPtr->initialize();

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -46,7 +46,7 @@ using PortMapIterator = PortMap::iterator;
 /**
  *@class MuxManager
  *
- *@brief host collection MuxPort object, each has MuxPort configuration, LinkManagerStateMachine.
+ *@brief host collection MuxPort object, each has MuxPort configuration, ActiveStandbyStateMachine.
  */
 class MuxManager
 {

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -81,7 +81,7 @@ void MuxPort::handleBladeIpv4AddressUpdate(boost::asio::ip::address address)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleSwssBladeIpv4AddressUpdate,
+        &link_manager::ActiveStandbyStateMachine::handleSwssBladeIpv4AddressUpdate,
         &mLinkManagerStateMachine,
         address
     )));
@@ -103,7 +103,7 @@ void MuxPort::handleLinkState(const std::string &linkState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleSwssLinkStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handleSwssLinkStateNotification,
         &mLinkManagerStateMachine,
         label
     )));
@@ -125,7 +125,7 @@ void MuxPort::handlePeerLinkState(const std::string &linkState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handlePeerLinkStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handlePeerLinkStateNotification,
         &mLinkManagerStateMachine,
         label
     )));
@@ -142,7 +142,7 @@ void MuxPort::handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleGetServerMacAddressNotification,
+        &link_manager::ActiveStandbyStateMachine::handleGetServerMacAddressNotification,
         &mLinkManagerStateMachine,
         address
     )));
@@ -168,7 +168,7 @@ void MuxPort::handleGetMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleGetMuxStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handleGetMuxStateNotification,
         &mLinkManagerStateMachine,
         label
     )));
@@ -192,7 +192,7 @@ void MuxPort::handleProbeMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleProbeMuxStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handleProbeMuxStateNotification,
         &mLinkManagerStateMachine,
         label
     )));
@@ -218,7 +218,7 @@ void MuxPort::handleMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleMuxStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handleMuxStateNotification,
         &mLinkManagerStateMachine,
         label
     )));
@@ -244,7 +244,7 @@ void MuxPort::handleMuxConfig(const std::string &config)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleMuxConfigNotification,
+        &link_manager::ActiveStandbyStateMachine::handleMuxConfigNotification,
         &mLinkManagerStateMachine,
         mode
     )));
@@ -261,7 +261,7 @@ void MuxPort::handleDefaultRouteState(const std::string &routeState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleDefaultRouteStateNotification,
+        &link_manager::ActiveStandbyStateMachine::handleDefaultRouteStateNotification,
         &mLinkManagerStateMachine,
         routeState
     )));
@@ -278,7 +278,7 @@ void MuxPort::resetPckLossCount()
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleResetLinkProberPckLossCount,
+        &link_manager::ActiveStandbyStateMachine::handleResetLinkProberPckLossCount,
         &mLinkManagerStateMachine
     )));
 }

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -143,7 +143,7 @@ public:
     *
     *@return none
     */
-    inline void setMuxLinkmgrState(link_manager::LinkManagerStateMachine::Label label) {
+    inline void setMuxLinkmgrState(link_manager::ActiveStandbyStateMachine::Label label) {
         mDbInterfacePtr->setMuxLinkmgrState(mMuxPortConfig.getPortName(), label);
     };
 
@@ -158,7 +158,7 @@ public:
     *@return none
     */
     inline void postMetricsEvent(
-        link_manager::LinkManagerStateMachine::Metrics metrics,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
     ) {
         mDbInterfacePtr->postMetricsEvent(mMuxPortConfig.getPortName(), metrics, label);
@@ -173,7 +173,7 @@ public:
      * 
      * @return none
     */
-    inline void postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics metrics) {
+    inline void postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics) {
         mDbInterfacePtr->postLinkProberMetricsEvent(mMuxPortConfig.getPortName(), metrics);
     };
 
@@ -316,11 +316,11 @@ protected:
     /**
     *@method getLinkManagerStateMachine
     *
-    *@brief getter for LinkManagerStateMachine object (used during unit test)
+    *@brief getter for ActiveStandbyStateMachine object (used during unit test)
     *
-    *@return pointer to LinkManagerStateMachine object
+    *@return pointer to ActiveStandbyStateMachine object
     */
-    link_manager::LinkManagerStateMachine* getLinkManagerStateMachine() {return &mLinkManagerStateMachine;};
+    link_manager::ActiveStandbyStateMachine* getLinkManagerStateMachine() {return &mLinkManagerStateMachine;};
 
     /**
     *@method setComponentInitState
@@ -336,7 +336,7 @@ private:
     common::MuxPortConfig mMuxPortConfig;
     boost::asio::io_service::strand mStrand;
 
-    link_manager::LinkManagerStateMachine mLinkManagerStateMachine;
+    link_manager::ActiveStandbyStateMachine mLinkManagerStateMachine;
 };
 
 } /* namespace mux */

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -31,6 +31,7 @@
 #include "common/MuxPortConfig.h"
 
 namespace link_manager {
+class LinkManagerStateMachineBase;
 class ActiveStandbyStateMachine;
 }
 
@@ -105,6 +106,7 @@ public:
     boost::asio::io_service::strand& getStrand() {return mStrand;};
 
 private:
+    friend class link_manager::LinkManagerStateMachineBase;
     friend class link_manager::ActiveStandbyStateMachine;
     friend class link_prober::LinkProberStateMachine;
     friend class mux_state::MuxStateMachine;

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -31,7 +31,7 @@
 #include "common/MuxPortConfig.h"
 
 namespace link_manager {
-class LinkManagerStateMachine;
+class ActiveStandbyStateMachine;
 }
 
 namespace link_prober {
@@ -105,7 +105,7 @@ public:
     boost::asio::io_service::strand& getStrand() {return mStrand;};
 
 private:
-    friend class link_manager::LinkManagerStateMachine;
+    friend class link_manager::ActiveStandbyStateMachine;
     friend class link_prober::LinkProberStateMachine;
     friend class mux_state::MuxStateMachine;
     friend class link_state::LinkStateMachine;

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -15,7 +15,7 @@
  */
 
 /*
- * LinkManagerStateMachine.h
+ * ActiveStandbyStateMachine.h
  *
  *  Created on: Oct 18, 2020
  *      Author: tamer
@@ -88,12 +88,12 @@ public:
 };
 
 /**
- *@class LinkManagerStateMachine
+ *@class ActiveStandbyStateMachine
  *
  *@brief Composite state machine of LinkProberState, MuxState, and LinkState
  */
-class LinkManagerStateMachine: public common::StateMachine,
-                               public std::enable_shared_from_this<LinkManagerStateMachine>
+class ActiveStandbyStateMachine: public common::StateMachine,
+                               public std::enable_shared_from_this<ActiveStandbyStateMachine>
 {
 public:
     /**
@@ -148,27 +148,27 @@ public:
         mux_state::MuxState::Label,
         link_state::LinkState::Label
     >;
-    using TransitionFunction = std::function<void (LinkManagerStateMachine*, CompositeState&)>;
+    using TransitionFunction = std::function<void (ActiveStandbyStateMachine*, CompositeState&)>;
 
 public:
     /**
-    *@method LinkManagerStateMachine
+    *@method ActiveStandbyStateMachine
     *
     *@brief class default constructor
     */
-    LinkManagerStateMachine() = delete;
+    ActiveStandbyStateMachine() = delete;
 
     /**
-    *@method LinkManagerStateMachine
+    *@method ActiveStandbyStateMachine
     *
     *@brief class copy constructor
     *
-    *@param LinkManagerStateMachine (in)  reference to LinkManagerStateMachine object to be copied
+    *@param ActiveStandbyStateMachine (in)  reference to ActiveStandbyStateMachine object to be copied
     */
-    LinkManagerStateMachine(const LinkManagerStateMachine &) = delete;
+    ActiveStandbyStateMachine(const ActiveStandbyStateMachine &) = delete;
 
     /**
-    *@method LinkManagerStateMachine
+    *@method ActiveStandbyStateMachine
     *
     *@brief class constructor
     *
@@ -176,18 +176,18 @@ public:
     *@param strand (in)         boost serialization object
     *@param muxPortConfig (in)  reference to MuxPortConfig object
     */
-    LinkManagerStateMachine(
+    ActiveStandbyStateMachine(
         mux::MuxPort *muxPortPtr,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig
     );
 
     /**
-    *@method ~LinkManagerStateMachine
+    *@method ~ActiveStandbyStateMachine
     *
     *@brief class destructor
     */
-    virtual ~LinkManagerStateMachine() = default;
+    virtual ~ActiveStandbyStateMachine() = default;
 
     /**
     *@method initializeTransitionFunctionTable

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/bind/bind.hpp>
+
+#include "MuxPort.h"
+#include "common/MuxException.h"
+#include "common/MuxLogger.h"
+#include "link_manager/LinkManagerStateMachineBase.h"
+
+namespace link_manager {
+LinkProberEvent LinkManagerStateMachineBase::mLinkProberEvent;
+MuxStateEvent LinkManagerStateMachineBase::mMuxStateEvent;
+LinkStateEvent LinkManagerStateMachineBase::mLinkStateEvent;
+
+std::vector<std::string> LinkManagerStateMachineBase::mLinkProberStateName = {"Active", "Standby", "Unknown", "Wait"};
+std::vector<std::string> LinkManagerStateMachineBase::mMuxStateName = {"Active", "Standby", "Unknown", "Error", "Wait"};
+std::vector<std::string> LinkManagerStateMachineBase::mLinkStateName = {"Up", "Down"};
+std::vector<std::string> LinkManagerStateMachineBase::mLinkHealthName = {"Uninitialized", "Unhealthy", "Healthy"};
+
+//
+// ---> LinkManagerStateMachineBase::LinkManagerStateMachineBase(
+//             boost::asio::io_service::strand &strand,
+//             common::MuxPortConfig &muxPortConfig,
+//             CompositeState initialCompositeState);
+//
+// class constructor
+//
+LinkManagerStateMachineBase::LinkManagerStateMachineBase(
+    boost::asio::io_service::strand &strand,
+    common::MuxPortConfig &muxPortConfig,
+    CompositeState initialCompositeState)
+    : StateMachine(strand, muxPortConfig),
+      mCompositeState(initialCompositeState) {
+}
+
+//
+// ---> initializeTransitionFunctionTable()
+//
+// initialize transition function table to NOOP functions
+//
+void LinkManagerStateMachineBase::initializeTransitionFunctionTable() {
+    MUXLOGWARNING("Initialize State Transition Table With NO-OP...");
+    for (uint8_t linkProberState = link_prober::LinkProberState::Label::Active;
+         linkProberState < link_prober::LinkProberState::Label::Count;
+         linkProberState++) {
+        for (uint8_t muxState = mux_state::MuxState::Label::Active;
+             muxState < mux_state::MuxState::Label::Count; muxState++) {
+            for (uint8_t linkState = link_state::LinkState::Label::Up;
+                 linkState < link_state::LinkState::Label::Count; linkState++) {
+                mStateTransitionHandler[linkProberState][muxState][linkState] = boost::bind(&LinkManagerStateMachineBase::noopTransitionFunction, this, boost::placeholders::_1);
+            }
+        }
+    }
+}
+
+//
+// ---> noopTransitionFunction(CompositeState &nextState)
+//
+// NO-OP transition function
+//
+void LinkManagerStateMachineBase::noopTransitionFunction(CompositeState &nextState) {
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+} /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -1,0 +1,258 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINK_MANAGER_LINKMANAGERSTATEMACHINEBASE_H_
+#define LINK_MANAGER_LINKMANAGERSTATEMACHINEBASE_H_
+
+#include <bitset>
+#include <boost/function.hpp>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "link_prober/LinkProber.h"
+#include "link_prober/LinkProberState.h"
+#include "link_state/LinkState.h"
+#include "link_state/LinkStateMachine.h"
+#include "mux_state/MuxState.h"
+#include "mux_state/MuxStateMachine.h"
+
+namespace mux {
+#define ps(compositeState) std::get<0>(compositeState)
+#define ms(compositeState) std::get<1>(compositeState)
+#define ls(compositeState) std::get<2>(compositeState)
+
+class MuxPort;
+};  // namespace mux
+
+namespace link_manager {
+class ActiveStandbyStateMachine;
+
+/**
+ *@class LinkProberEvent
+ *
+ *@brief signals a LinkeProber event to the composite state machine
+ */
+class LinkProberEvent {
+public:
+    LinkProberEvent() = default;
+    ~LinkProberEvent() = default;
+};
+
+/**
+ *@class MuxStateEvent
+ *
+ *@brief signals a MuxState event to the composite state machine
+ */
+class MuxStateEvent {
+public:
+    MuxStateEvent() = default;
+    ~MuxStateEvent() = default;
+};
+
+/**
+ *@class LinkStateEvent
+ *
+ *@brief signals a LinkState event to the composite state machine
+ */
+class LinkStateEvent {
+public:
+    LinkStateEvent() = default;
+    ~LinkStateEvent() = default;
+};
+
+/**
+ *@class LinkManagerStateMachineBase
+ *
+ *@brief Abstrct composite state machine of LinkPorberState, MuxState, and LinkState
+ */
+class LinkManagerStateMachineBase : public common::StateMachine {
+public:
+    /**
+     *@enum Label
+     *
+     *@brief Label corresponding to each LINKMGR Health State
+     */
+    enum class Label {
+        Uninitialized,
+        Unhealthy,
+        Healthy,
+
+        Count
+    };
+
+    using CompositeState = std::tuple<link_prober::LinkProberState::Label,
+                                      mux_state::MuxState::Label,
+                                      link_state::LinkState::Label>;
+    using TransitionFunction = std::function<void(CompositeState&)>;
+
+public:
+    /**
+     *@method LinkManagerStateMachineBase
+     * 
+     *@brief class default constructor
+     */
+    LinkManagerStateMachineBase() = delete;
+
+    /**
+     * @method LinkManagerStateMachineBase 
+     * 
+     * @brief class copy constructor
+     * 
+     * @param LinkManagerStateMachineBase   reference to LinkManagerStateMachineBase object to be copied 
+     */
+    LinkManagerStateMachineBase(const LinkManagerStateMachineBase&) = delete;
+
+    /**
+     * @method LinkManagerStateMachineBase
+     * 
+     * @brief Construct a new LinkManagerStateMachineBase object
+     * 
+     * @param strand                        boost serialization object 
+     * @param muxPortConfig                 reference to MuxPortConfig object
+     * @param initialCompositeState         initial Composite states
+     */
+    LinkManagerStateMachineBase(
+        boost::asio::io_service::strand& strand,
+        common::MuxPortConfig& muxPortConfig,
+        CompositeState initialCompositeState);
+
+    /**
+     * @method ~LinkManagerStateMachineBase
+     * 
+     * @brief Destroy the Link Manager State Machine Base object
+     */
+    virtual ~LinkManagerStateMachineBase() = default;
+
+    /**
+     * @method initializeTransitionFunctionTable
+     * 
+     * @brief Initialize the transition function table
+     */
+    virtual void initializeTransitionFunctionTable() = 0;
+
+    /**
+     * @method handleStateChange
+     * 
+     * @brief handle LinkProberEvent 
+     * 
+     * @param event                         reference to LinkProberEvent object
+     * @param state                         new LinkProberState label
+     */
+    virtual void handleStateChange(LinkProberEvent& event, link_prober::LinkProberState::Label state) = 0;
+
+    /**
+     * @method handleStateChange
+     * 
+     * @brief handle MuxStateEvent 
+     * 
+     * @param event                         reference to MuxStateEvent object
+     * @param state                         new MuxStateEvent label
+     */
+    virtual void handleStateChange(MuxStateEvent& event, mux_state::MuxState::Label state) = 0;
+
+    /**
+     * @method handleStateChange
+     * 
+     * @brief handle LinkStateEvent 
+     * 
+     * @param event                         reference to LinkStateEvent object
+     * @param state                         new LinkStateEvent label
+     */
+    virtual void handleStateChange(LinkStateEvent& event, link_state::LinkState::Label state) = 0;
+
+    /**
+     * @method getLinkProberEvent
+     * 
+     * @brief Get the Link Prober Event object
+     * 
+     * @return LinkProberEvent& 
+     */
+    static LinkProberEvent& getLinkProberEvent() { return mLinkProberEvent; };
+
+    /**
+     * @method getMuxStateEvent
+     * 
+     * @brief Get the Mux State Event object
+     * 
+     * @return MuxStateEvent& 
+     */
+    static MuxStateEvent& getMuxStateEvent() { return mMuxStateEvent; };
+
+    /**
+     * @method getLinkStateEvent
+     * 
+     * @brief Get the Link State Event object
+     * 
+     * @return LinkStateEvent& 
+     */
+    static LinkStateEvent& getLinkStateEvent() { return mLinkStateEvent; };
+
+    /**
+     * @method getCompositeState
+     * 
+     * @brief Get the Composite State object
+     * 
+     * @return const CompositeState& 
+     */
+    const CompositeState& getCompositeState() { return mCompositeState; };
+
+private:
+    friend class ActiveStandbyStateMachine;
+
+private:
+    /**
+     * @method setLabel
+     * 
+     * @brief Set the Linkmgr STATE_DB state
+     * 
+     * @param label 
+     */
+    virtual inline void setLabel(Label label) = 0;
+
+    /**
+     * @method noopTransitionFunction
+     * 
+     * @brief NO-OP transition function
+     * 
+     * @param nextState                     reference to CompositeState object
+     */
+    void noopTransitionFunction(CompositeState& nextState);
+
+private:
+    static LinkProberEvent mLinkProberEvent;
+    static MuxStateEvent mMuxStateEvent;
+    static LinkStateEvent mLinkStateEvent;
+
+    // To print human readable state name
+    static std::vector<std::string> mLinkProberStateName;
+    static std::vector<std::string> mMuxStateName;
+    static std::vector<std::string> mLinkStateName;
+    static std::vector<std::string> mLinkHealthName;
+
+private:
+    TransitionFunction mStateTransitionHandler[link_prober::LinkProberState::Label::Count]
+                                              [mux_state::MuxState::Label::Count]
+                                              [link_state::LinkState::Label::Count];
+    LinkManagerStateMachineBase::CompositeState mCompositeState;
+
+    Label mLabel = Label::Uninitialized;
+};
+
+} /* namespace link_manager */
+
+#endif /* LINK_MANAGER_LINKMANAGERSTATEMACHINEBASE_H_ */

--- a/src/link_manager/subdir.mk
+++ b/src/link_manager/subdir.mk
@@ -1,13 +1,16 @@
 # Add inputs and outputs from these tool invocations to the build variables 
 CPP_SRCS += \
-    ./src/link_manager/LinkManagerStateMachine.cpp 
+	./src/link_manager/LinkManagerStateMachineBase.cpp \
+    ./src/link_manager/LinkManagerStateMachine.cpp \
 
 OBJS += \
-    ./src/link_manager/LinkManagerStateMachine.o 
+	./src/link_manager/LinkManagerStateMachineBase.o \
+    ./src/link_manager/LinkManagerStateMachine.o \
+ 
 
 CPP_DEPS += \
-    ./src/link_manager/LinkManagerStateMachine.d 
-
+	./src/link_manager/LinkManagerStateMachineBase.d \
+    ./src/link_manager/LinkManagerStateMachine.d \
 
 # Each subdirectory must supply rules for building sources it contributes
 src/link_manager/%.o: src/link_manager/%.cpp

--- a/src/link_prober/LinkProberStateMachine.cpp
+++ b/src/link_prober/LinkProberStateMachine.cpp
@@ -43,7 +43,7 @@ SwitchActiveRequestEvent LinkProberStateMachine::mSwitchActiveRequestEvent;
 
 //
 // ---> LinkProberStateMachine(
-//          link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+//          link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
 //          boost::asio::io_service::strand &strand,
 //          common::MuxPortConfig &muxPortConfig,
 //          LinkProberState::Label label
@@ -52,7 +52,7 @@ SwitchActiveRequestEvent LinkProberStateMachine::mSwitchActiveRequestEvent;
 // class constructor
 //
 LinkProberStateMachine::LinkProberStateMachine(
-    link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+    link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
     boost::asio::io_service::strand &strand,
     common::MuxPortConfig &muxPortConfig,
     LinkProberState::Label label
@@ -104,10 +104,10 @@ void LinkProberStateMachine::postLinkManagerEvent(LinkProberState* linkProberSta
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        static_cast<void (link_manager::LinkManagerStateMachine::*) (link_manager::LinkProberEvent&, LinkProberState::Label)>
-            (&link_manager::LinkManagerStateMachine::handleStateChange),
+        static_cast<void (link_manager::ActiveStandbyStateMachine::*) (link_manager::LinkProberEvent&, LinkProberState::Label)>
+            (&link_manager::ActiveStandbyStateMachine::handleStateChange),
         &mLinkManagerStateMachine,
-        link_manager::LinkManagerStateMachine::getLinkProberEvent(),
+        link_manager::ActiveStandbyStateMachine::getLinkProberEvent(),
         linkProberState->getStateLabel()
     )));
 }
@@ -204,7 +204,7 @@ void LinkProberStateMachine::processEvent(SuspendTimerExpiredEvent &suspendTimer
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleSuspendTimerExpiry,
+        &link_manager::ActiveStandbyStateMachine::handleSuspendTimerExpiry,
         &mLinkManagerStateMachine
     )));
 }
@@ -219,7 +219,7 @@ void LinkProberStateMachine::processEvent(SwitchActiveCommandCompleteEvent &swit
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleSwitchActiveCommandCompletion,
+        &link_manager::ActiveStandbyStateMachine::handleSwitchActiveCommandCompletion,
         &mLinkManagerStateMachine
     )));
 }
@@ -234,7 +234,7 @@ void LinkProberStateMachine::processEvent(SwitchActiveRequestEvent &switchActive
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleSwitchActiveRequestEvent,
+        &link_manager::ActiveStandbyStateMachine::handleSwitchActiveRequestEvent,
         &mLinkManagerStateMachine
     )));
 }
@@ -249,7 +249,7 @@ void LinkProberStateMachine::handleMackAddressUpdate(const std::array<uint8_t, E
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleGetServerMacAddressNotification,
+        &link_manager::ActiveStandbyStateMachine::handleGetServerMacAddressNotification,
         &mLinkManagerStateMachine,
         address
     )));
@@ -265,7 +265,7 @@ void LinkProberStateMachine::handlePckLossRatioUpdate(const uint64_t unknownEven
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handlePostPckLossRatioNotification,
+        &link_manager::ActiveStandbyStateMachine::handlePostPckLossRatioNotification,
         &mLinkManagerStateMachine,
         unknownEventCount,
         expectedPacketCount

--- a/src/link_prober/LinkProberStateMachine.h
+++ b/src/link_prober/LinkProberStateMachine.h
@@ -31,7 +31,7 @@
 #include "link_prober/WaitState.h"
 
 namespace link_manager {
-class LinkManagerStateMachine;
+class ActiveStandbyStateMachine;
 } /* namespace link_manager */
 
 namespace link_prober
@@ -131,13 +131,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to LinkManagerStateMachine
+    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     LinkProberStateMachine(
-        link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         LinkProberState::Label label
@@ -352,7 +352,7 @@ private:
     static SwitchActiveRequestEvent mSwitchActiveRequestEvent;
 
 private:
-    link_manager::LinkManagerStateMachine &mLinkManagerStateMachine;
+    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
     ActiveState mActiveState;
     StandbyState mStandbyState;
     UnknownState mUnknownState;

--- a/src/link_state/LinkStateMachine.cpp
+++ b/src/link_state/LinkStateMachine.cpp
@@ -38,7 +38,7 @@ DownEvent LinkStateMachine::mDownEvent;
 
 //
 // ---> LinkStateMachine(
-//          link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+//          link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
 //          boost::asio::io_service::strand &strand,
 //          common::MuxPortConfig &muxPortConfig,
 //          LinkState::Label label
@@ -47,7 +47,7 @@ DownEvent LinkStateMachine::mDownEvent;
 // class constructor
 //
 LinkStateMachine::LinkStateMachine(
-    link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+    link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
     boost::asio::io_service::strand &strand,
     common::MuxPortConfig &muxPortConfig,
     LinkState::Label label
@@ -91,10 +91,10 @@ void LinkStateMachine::postLinkManagerEvent(LinkState* linkState)
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        static_cast<void (link_manager::LinkManagerStateMachine::*) (link_manager::LinkStateEvent&, LinkState::Label)>
-            (&link_manager::LinkManagerStateMachine::handleStateChange),
+        static_cast<void (link_manager::ActiveStandbyStateMachine::*) (link_manager::LinkStateEvent&, LinkState::Label)>
+            (&link_manager::ActiveStandbyStateMachine::handleStateChange),
         &mLinkManagerStateMachine,
-        link_manager::LinkManagerStateMachine::getLinkStateEvent(),
+        link_manager::ActiveStandbyStateMachine::getLinkStateEvent(),
         linkState->getStateLabel()
     )));
 }

--- a/src/link_state/LinkStateMachine.h
+++ b/src/link_state/LinkStateMachine.h
@@ -29,7 +29,7 @@
 #include "UpState.h"
 
 namespace link_manager {
-class LinkManagerStateMachine;
+class ActiveStandbyStateMachine;
 } /* namespace link_manager */
 
 namespace link_state
@@ -85,13 +85,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to LinkManagerStateMachine
+    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     LinkStateMachine(
-        link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         LinkState::Label label
@@ -192,7 +192,7 @@ private:
     static DownEvent mDownEvent;
 
 private:
-    link_manager::LinkManagerStateMachine &mLinkManagerStateMachine;
+    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
     UpState mUpState;
     DownState mDownState;
 };

--- a/src/mux_state/MuxStateMachine.cpp
+++ b/src/mux_state/MuxStateMachine.cpp
@@ -40,7 +40,7 @@ ErrorEvent MuxStateMachine::mErrorEvent;
 
 //
 // ---> MuxStateMachine(
-//          link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+//          link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
 //          boost::asio::io_service::strand &strand,
 //          common::MuxPortConfig &muxPortConfig,
 //          MuxState::Label label
@@ -49,7 +49,7 @@ ErrorEvent MuxStateMachine::mErrorEvent;
 // class constructor
 //
 MuxStateMachine::MuxStateMachine(
-    link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+    link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
     boost::asio::io_service::strand &strand,
     common::MuxPortConfig &muxPortConfig,
     MuxState::Label label
@@ -105,10 +105,10 @@ void MuxStateMachine::postLinkManagerEvent(MuxState* muxState)
     boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        static_cast<void (link_manager::LinkManagerStateMachine::*) (link_manager::MuxStateEvent&, MuxState::Label)>
-            (&link_manager::LinkManagerStateMachine::handleStateChange),
+        static_cast<void (link_manager::ActiveStandbyStateMachine::*) (link_manager::MuxStateEvent&, MuxState::Label)>
+            (&link_manager::ActiveStandbyStateMachine::handleStateChange),
         &mLinkManagerStateMachine,
-        link_manager::LinkManagerStateMachine::getMuxStateEvent(),
+        link_manager::ActiveStandbyStateMachine::getMuxStateEvent(),
         muxState->getStateLabel()
     )));
 }

--- a/src/mux_state/MuxStateMachine.h
+++ b/src/mux_state/MuxStateMachine.h
@@ -32,7 +32,7 @@
 #include "mux_state/UnknownState.h"
 
 namespace link_manager {
-class LinkManagerStateMachine;
+class ActiveStandbyStateMachine;
 } /* namespace link_manager */
 
 namespace mux_state
@@ -110,13 +110,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to LinkManagerStateMachine
+    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     MuxStateMachine(
-        link_manager::LinkManagerStateMachine &linkManagerStateMachine,
+        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         MuxState::Label label
@@ -284,7 +284,7 @@ private:
     static ErrorEvent mErrorEvent;
 
 private:
-    link_manager::LinkManagerStateMachine &mLinkManagerStateMachine;
+    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
     ActiveState mActiveState;
     StandbyState mStandbyState;
     UnknownState mUnknownState;

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -53,14 +53,14 @@ void FakeDbInterface::probeMuxState(const std::string &portName)
     mProbeMuxStateInvokeCount++;
 }
 
-void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::LinkManagerStateMachine::Label label)
+void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label)
 {
     mSetMuxLinkmgrStateInvokeCount++;
 }
 
 void FakeDbInterface::postMetricsEvent(
     const std::string &portName,
-    link_manager::LinkManagerStateMachine::Metrics metrics,
+    link_manager::ActiveStandbyStateMachine::Metrics metrics,
     mux_state::MuxState::Label label
 )
 {
@@ -69,7 +69,7 @@ void FakeDbInterface::postMetricsEvent(
 
 void FakeDbInterface::postLinkProberMetricsEvent(
         const std::string &portName, 
-        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
+        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics
 )
 {
     mPostLinkProberMetricsInvokeCount++;

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -41,16 +41,16 @@ public:
     virtual void probeMuxState(const std::string &portName) override;
     virtual void setMuxLinkmgrState(
         const std::string &portName,
-        link_manager::LinkManagerStateMachine::Label label
+        link_manager::ActiveStandbyStateMachine::Label label
     ) override;
     virtual void postMetricsEvent(
         const std::string &portName,
-        link_manager::LinkManagerStateMachine::Metrics metrics,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
     ) override;
     virtual void postLinkProberMetricsEvent(
         const std::string &portName, 
-        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
+        link_manager::ActiveStandbyStateMachine::LinkProberMetrics metrics
     ) override;
     virtual void postPckLossRatio(
         const std::string &portName,

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -52,7 +52,6 @@ FakeMuxPort::FakeMuxPort(
     std::string log_filename = "/tmp/" + prog_name + ".log";
     common::MuxLogger::getInstance()->initialize(prog_name, log_filename, boost::log::trivial::debug);
     common::MuxLogger::getInstance()->setLevel(boost::log::trivial::trace);
-    link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
     mMuxPortConfig.setMode(common::MuxPortConfig::Mode::Auto);
     getLinkManagerStateMachine()->setInitializeProberFnPtr(
         boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -52,7 +52,7 @@ FakeMuxPort::FakeMuxPort(
     std::string log_filename = "/tmp/" + prog_name + ".log";
     common::MuxLogger::getInstance()->initialize(prog_name, log_filename, boost::log::trivial::debug);
     common::MuxLogger::getInstance()->setLevel(boost::log::trivial::trace);
-    link_manager::LinkManagerStateMachine::initializeTransitionFunctionTable();
+    link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
     mMuxPortConfig.setMode(common::MuxPortConfig::Mode::Auto);
     getLinkManagerStateMachine()->setInitializeProberFnPtr(
         boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -48,7 +48,7 @@ public:
 
     void activateStateMachine();
 
-    const link_manager::LinkManagerStateMachine::CompositeState& getCompositeState() {return getLinkManagerStateMachine()->getCompositeState();};
+    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() {return getLinkManagerStateMachine()->getCompositeState();};
     link_prober::LinkProberStateMachine& getLinkProberStateMachine() {return getLinkManagerStateMachine()->getLinkProberStateMachine();};
     mux_state::MuxStateMachine& getMuxStateMachine() {return getLinkManagerStateMachine()->getMuxStateMachine();};
     link_state::LinkStateMachine& getLinkStateMachine() {return getLinkManagerStateMachine()->getLinkStateMachine();};

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -65,7 +65,7 @@ public:
     uint16_t mServerId = 01;
 
     FakeMuxPort mFakeMuxPort;
-    link_manager::LinkManagerStateMachine::CompositeState mTestCompositeState;
+    link_manager::ActiveStandbyStateMachine::CompositeState mTestCompositeState;
 
     uint8_t mPositiveUpdateCount = 2;
 };

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -38,7 +38,7 @@ MuxManagerTest::MuxManagerTest() :
     mMuxManagerPtr->setDbInterfacePtr(mDbInterfacePtr);
 
     link_prober::IcmpPayload::generateGuid();
-    link_manager::LinkManagerStateMachine::initializeTransitionFunctionTable();
+    link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
 }
 
 void MuxManagerTest::runIoService(uint32_t count)
@@ -123,7 +123,7 @@ void MuxManagerTest::processMuxPortConfigNotifiction(std::deque<swss::KeyOpField
     mDbInterfacePtr->processMuxPortConfigNotifiction(entries);
 }
 
-link_manager::LinkManagerStateMachine::CompositeState MuxManagerTest::getCompositeStateMachineState(std::string port)
+link_manager::ActiveStandbyStateMachine::CompositeState MuxManagerTest::getCompositeStateMachineState(std::string port)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
 
@@ -186,14 +186,14 @@ void MuxManagerTest::createPort(std::string port)
 
     mDbInterfacePtr->processLinkStateNotifiction(entries);
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap["Ethernet0"];
-    link_manager::LinkManagerStateMachine* linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachine();
+    link_manager::ActiveStandbyStateMachine* linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachine();
 
     EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachine::LinkStateComponent) == 0);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::LinkStateComponent) == 0);
 
     runIoService();
 
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachine::LinkStateComponent) == 1);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::LinkStateComponent) == 1);
 
     // Initialize a FakeLinkProber
     mFakeLinkProber = std::make_shared<FakeLinkProber> (&linkManagerStateMachine->getLinkProberStateMachine());
@@ -230,11 +230,11 @@ void MuxManagerTest::createPort(std::string port)
 
     mDbInterfacePtr->processMuxStateNotifiction(entries);
     EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachine::MuxStateComponent) == 0);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::MuxStateComponent) == 0);
 
     runIoService();
 
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachine::MuxStateComponent) == 1);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::MuxStateComponent) == 1);
 }
 
 TEST_F(MuxManagerTest, AddPort)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -38,7 +38,6 @@ MuxManagerTest::MuxManagerTest() :
     mMuxManagerPtr->setDbInterfacePtr(mDbInterfacePtr);
 
     link_prober::IcmpPayload::generateGuid();
-    link_manager::ActiveStandbyStateMachine::initializeTransitionFunctionTable();
 }
 
 void MuxManagerTest::runIoService(uint32_t count)

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -57,7 +57,7 @@ public:
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getTorMacAddress(std::string port);
     void processMuxPortConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
-    link_manager::LinkManagerStateMachine::CompositeState getCompositeStateMachineState(std::string port);
+    link_manager::ActiveStandbyStateMachine::CompositeState getCompositeStateMachineState(std::string port);
     void processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
     void processServerMacAddress(std::string port, std::array<char, MAX_ADDR_SIZE + 1> ip, std::array<char, MAX_ADDR_SIZE + 1> mac);
     void processLoopback2InterfaceInfo(std::vector<std::string> &loopbackIntfs);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Add abstract class `LinkManagerStateMachineBase` to represent common interfaces for link manager state machines that could be shared by both active/active state machine and active/standby state machine.

#### How did you do it?
1. Rename `LinkManagerStateMachine` to `ActiveStandbyStateMachine`
2. Add abstract parent class `LinkManagerStateMachineBase`, which is derived from class `StateMachine`.
3. Let `ActiveStandbyStateMachine` be a child class of `LinkManagerStateMachineBase`

#### How did you verify/test it?
Build without error and all unit tests passed

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->