### PR TITLE
Incrementing tolerance on mux state inconsistency 

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -942,11 +942,11 @@ void LinkManagerStateMachine::handleMuxProbeTimeout(boost::system::error_code er
     if (errorCode == boost::system::errc::success &&
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Wait ||
          ms(mCompositeState) == mux_state::MuxState::Label::Unknown ||
-         ls(mCompositeState) == link_state::LinkState::Label::Down) ||
+         ls(mCompositeState) == link_state::LinkState::Label::Down ||
          (ps(mCompositeState) == link_prober::LinkProberState::Label::Standby &&
          ms(mCompositeState) == mux_state::MuxState::Label::Active) ||
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
-         ms(mCompositeState) == mux_state::MuxState::Label::Standby)) {
+         ms(mCompositeState) == mux_state::MuxState::Label::Standby))) {
         CompositeState currState = mCompositeState;
         enterMuxWaitState(mCompositeState);
         LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), currState, mCompositeState);

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -933,7 +933,7 @@ void LinkManagerStateMachine::startMuxProbeTimer(uint32_t factor)
 //
 // ---> handleMuxProbeTimeout(boost::system::error_code errorCode);
 //
-// handle when LinkProber heartbeats were lost due link down, bad cable or server down
+// handle when LinkProber heartbeats were lost due link down, bad cable, server down or state mismatching
 //
 void LinkManagerStateMachine::handleMuxProbeTimeout(boost::system::error_code errorCode)
 {
@@ -942,7 +942,11 @@ void LinkManagerStateMachine::handleMuxProbeTimeout(boost::system::error_code er
     if (errorCode == boost::system::errc::success &&
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Wait ||
          ms(mCompositeState) == mux_state::MuxState::Label::Unknown ||
-         ls(mCompositeState) == link_state::LinkState::Label::Down)) {
+         ls(mCompositeState) == link_state::LinkState::Label::Down) ||
+         (ps(mCompositeState) == link_prober::LinkProberState::Label::Standby &&
+         ms(mCompositeState) == mux_state::MuxState::Label::Active) ||
+        (ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
+         ms(mCompositeState) == mux_state::MuxState::Label::Standby)) {
         CompositeState currState = mCompositeState;
         enterMuxWaitState(mCompositeState);
         LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), currState, mCompositeState);
@@ -1065,8 +1069,15 @@ void LinkManagerStateMachine::LinkProberStandbyMuxActiveLinkUpTransitionFunction
 )
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
-    // Probe the MUX state as internal MUX state is active while LP reports standby link
-    enterMuxWaitState(nextState);
+
+    if ((ps(mCompositeState) != ps(nextState)) &&
+        (ps(nextState) == link_prober::LinkProberState::Label::Active ||
+         ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
+        enterMuxWaitState(nextState);
+    } else {
+        //
+        startMuxProbeTimer();
+    }
 }
 
 //
@@ -1095,7 +1106,13 @@ void LinkManagerStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunction
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
-    enterMuxWaitState(nextState);
+    if ((ps(mCompositeState) != ps(nextState)) &&
+        (ps(nextState) == link_prober::LinkProberState::Label::Active ||
+         ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
+        enterMuxWaitState(nextState);
+    } else {
+        startMuxProbeTimer();
+    }
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -946,7 +946,8 @@ void LinkManagerStateMachine::handleMuxProbeTimeout(boost::system::error_code er
          (ps(mCompositeState) == link_prober::LinkProberState::Label::Standby &&
          ms(mCompositeState) == mux_state::MuxState::Label::Active) ||
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
-         ms(mCompositeState) == mux_state::MuxState::Label::Standby))) {
+         ms(mCompositeState) == mux_state::MuxState::Label::Standby))
+    ) {
         CompositeState currState = mCompositeState;
         enterMuxWaitState(mCompositeState);
         LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), currState, mCompositeState);

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -1073,8 +1073,12 @@ void LinkManagerStateMachine::LinkProberStandbyMuxActiveLinkUpTransitionFunction
     if ((ps(mCompositeState) != ps(nextState)) &&
         (ps(nextState) == link_prober::LinkProberState::Label::Active ||
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
+        // If entering by link prober state change, probe mux state immediately. 
         enterMuxWaitState(nextState);
     } else {
+        // There can be a delay for hardware state change in switchovers.
+        // So if not entering by link prober state change, start a timer for mux state probing. 
+        // When timer expires and if link prober & mux state remain inconsistent, do mux state probing. 
         startMuxProbeTimer();
     }
 }
@@ -1108,8 +1112,12 @@ void LinkManagerStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunction
     if ((ps(mCompositeState) != ps(nextState)) &&
         (ps(nextState) == link_prober::LinkProberState::Label::Active ||
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
+        // If entering by link prober state change, probe mux state immediately.     
         enterMuxWaitState(nextState);
     } else {
+        // There can be a delay for hardware state change in switchovers.
+        // So if not entering by link prober state change, start a timer for mux state probing. 
+        // When timer expires and if link prober & mux state remain inconsistent, do mux state probing. 
         startMuxProbeTimer();
     }
 }

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -1075,7 +1075,6 @@ void LinkManagerStateMachine::LinkProberStandbyMuxActiveLinkUpTransitionFunction
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
         enterMuxWaitState(nextState);
     } else {
-        //
         startMuxProbeTimer();
     }
 }

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -550,7 +550,7 @@ private:
     /**
     *@method handleLinkWaitTimeout
     *
-    *@brief handle when LinkProber heartbeats were lost due link down, bad cable or server down
+    *@brief handle when LinkProber heartbeats were lost due link down, bad cable, server down or state mismatching
     *
     *@param errorCode (in)          timer error code
     *

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -418,7 +418,7 @@ INSTANTIATE_TEST_CASE_P(
     MuxResponseTest,
     ::testing::Values(
         std::make_tuple("active", 1, mux_state::MuxState::Label::Active),
-        std::make_tuple("standby", 3, mux_state::MuxState::Label::Wait),
+        std::make_tuple("standby", 3, mux_state::MuxState::Label::Standby),
         std::make_tuple("unknown", 3, mux_state::MuxState::Label::Wait),
         std::make_tuple("error", 3, mux_state::MuxState::Label::Wait)
     )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to handle ```config mux mode standby/active``` failure on healthy ports caused by unexpected mismatching mux probe response.

What I firstly observed is a mux state probing right after a switchover can be mismatching with state db, and there was no additional switchover happened between the toggle and probe. Conducted an experiment and further proved that there is a time gap between xcvrd's toggle and the mux probe state change. 

This can trigger an undesirable switchback, and eventually appears to be a failure of ```config mux mode```. 

* Issue
  For example, expected state change sequence of switching to active is: 
    ```
    standby (Link Prober), standby (Local Mux State) 
    -> wait, wait
    -> wait, active (receive mux state notification, indicating toggle completes) 
    -> active, active (receive self's heartbeat)
    ```
  It's normal to receive previous heartbeat from peer during the process, so the sequence can also be:
    ```
    standby, standby 
    -> wait, wait 
    -> standby, wait (receive previous HB from peer before toggle completes) 
    -> standby, active (receive mux state notification, indicating toggle completes) 
    -> state inconsistency triggers mux state probing through I2C 
    -> mux probe response: active + receive self's heartbeat 
    -> active, active
    ```
  But since we have the time gap mentioned above, a probe response can unexpectedly be ```standby```, linkmgrd will trigger another switchover to standby. 

* Fix
Previous, no matter how linkmgrd enter ```standby, active``` or ```active, standby``` composite state, an immediate mux probe will be triggered. 
Now, when entering ```standby, active``` or ```active, standby``` composite state, check: 
  * If entering by link prober state change, do mux probe immediately. 
     Cause with link prober state change, toggle on cable definitely happen already. 
  * If entering by mux state notification, start a 300 ms timer. 
     When timer expires, if inconsistency still occurs, do mux probe. 

What caused the delay? We will need further investigation. This PR is a workaround for unblocking purpose. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid toggle failure on healthy cables. 

#### How did you do it?
When receiving mux state change (from the switchover), hold for 300ms before mux state probing. 

#### How did you verify/test it?
Scripted 1000 switchovers on 24 ports. Can't reproduce the issue any more. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->