### PR TITLE
Support per-port cable type

### DIFF
--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -414,6 +414,28 @@ private:
     void getServerIpAddress(std::shared_ptr<swss::DBConnector> configDbConnector);
 
     /**
+    *@method processPortCableType
+    *
+    *@brief process port cable type and build a map of port name to cable type
+    *
+    *@param entries   config_db MUX_CABLE entries
+    *
+    *@return none
+    */
+    inline void processPortCableType(std::vector<swss::KeyOpFieldsValuesTuple> &entries);
+
+   /**
+    *@method getPortCableType
+    *
+    *@brief retrieve per port cable type
+    *
+    *@param configDbConnector   config db connector
+    *
+    *@return none
+    */
+    void getPortCableType(std::shared_ptr<swss::DBConnector> configDbConnector);
+
+    /**
     *@method processMuxPortConfigNotifiction
     *
     *@brief process MUX port configuration change notification

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -160,6 +160,24 @@ void MuxManager::updateMuxPortConfig(const std::string &portName, const std::str
     }
 }
 
+//
+// ---> updatePortCableType(const std::string &portName, const std::string &cableType);
+//
+// update port cable type
+//
+void MuxManager::updatePortCableType(const std::string &portName, const std::string &cableType)
+{
+    MUXLOGWARNING(boost::format("%s: Port cable type: %s") % portName % cableType);
+
+    common::MuxPortConfig::PortCableType portCableType;
+    if (cableType == "active-standby") {
+        portCableType = common::MuxPortConfig::PortCableType::ActiveStandby;
+    } else {
+        portCableType = common::MuxPortConfig::PortCableType::ActiveStandby;
+    }
+    mPortCableTypeMap.insert({portName, portCableType});
+}
+
 // 
 // ---> resetPckLossCount(const std::string &portName);
 //
@@ -308,7 +326,8 @@ std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &por
                 mMuxConfig,
                 portName,
                 serverId,
-                mIoService
+                mIoService,
+                mPortCableTypeMap[portName]
             );
             mPortMap.insert({portName, muxPortPtr});
         }

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -32,6 +32,7 @@
 
 #include "MuxPort.h"
 #include "common/MuxConfig.h"
+#include "common/MuxPortConfig.h"
 #include "DbInterface.h"
 
 namespace test {
@@ -42,6 +43,9 @@ namespace mux
 {
 using PortMap = std::map<std::string, std::shared_ptr<MuxPort>>;
 using PortMapIterator = PortMap::iterator;
+
+using PortCableTypeMap = std::map<std::string, common::MuxPortConfig::PortCableType>;
+using PortCableTypeMapIterator = PortCableTypeMap::iterator;
 
 /**
  *@class MuxManager
@@ -246,6 +250,18 @@ public:
     void updateMuxPortConfig(const std::string &portName, const std::string &linkState);
 
     /**
+    *@method updatePortCableType
+    *
+    *@brief update port cable type
+    *
+    *@param portName (in)   port name
+    *@param cableType (in)  port cable type
+    *
+    *@return none
+    */
+    void updatePortCableType(const std::string &portName, const std::string &cableType);
+
+    /**
      * @method resetPckLossCount
      * 
      * @brief reset ICMP packet loss count. 
@@ -396,6 +412,7 @@ private:
     std::shared_ptr<mux::DbInterface> mDbInterfacePtr;
 
     PortMap mPortMap;
+    PortCableTypeMap mPortCableTypeMap;
 
     std::string mIpv4DefaultRouteState = "na";
     std::string mIpv6DefaultRouteState = "na";

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -57,22 +57,27 @@ MuxPort::MuxPort(
     common::MuxConfig &muxConfig,
     const std::string &portName,
     uint16_t serverId,
-    boost::asio::io_service &ioService
+    boost::asio::io_service &ioService,
+    common::MuxPortConfig::PortCableType portCableType
 ) :
     mDbInterfacePtr(dbInterfacePtr),
     mMuxPortConfig(
         muxConfig,
         portName,
-        serverId
+        serverId,
+        portCableType
     ),
-    mStrand(ioService),
-    mLinkManagerStateMachine(
-        this,
-        mStrand,
-        mMuxPortConfig
-    )
+    mStrand(ioService)
 {
     assert(dbInterfacePtr != nullptr);
+    if (portCableType == common::MuxPortConfig::PortCableType::ActiveStandby) {
+        mLinkManagerStateMachinePtr = std::make_shared<link_manager::ActiveStandbyStateMachine>(
+            this,
+            mStrand,
+            mMuxPortConfig
+        );
+    }
+    assert(mLinkManagerStateMachinePtr.get() != nullptr);
 }
 
 void MuxPort::handleBladeIpv4AddressUpdate(boost::asio::ip::address address)
@@ -81,8 +86,8 @@ void MuxPort::handleBladeIpv4AddressUpdate(boost::asio::ip::address address)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleSwssBladeIpv4AddressUpdate,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleSwssBladeIpv4AddressUpdate,
+        mLinkManagerStateMachinePtr.get(),
         address
     )));
 }
@@ -103,8 +108,8 @@ void MuxPort::handleLinkState(const std::string &linkState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleSwssLinkStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleSwssLinkStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         label
     )));
 }
@@ -125,8 +130,8 @@ void MuxPort::handlePeerLinkState(const std::string &linkState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handlePeerLinkStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handlePeerLinkStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         label
     )));
 }
@@ -142,8 +147,8 @@ void MuxPort::handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleGetServerMacAddressNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleGetServerMacAddressNotification,
+        mLinkManagerStateMachinePtr.get(),
         address
     )));
 }
@@ -168,8 +173,8 @@ void MuxPort::handleGetMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleGetMuxStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleGetMuxStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         label
     )));
 }
@@ -192,8 +197,8 @@ void MuxPort::handleProbeMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleProbeMuxStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleProbeMuxStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         label
     )));
 }
@@ -218,8 +223,8 @@ void MuxPort::handleMuxState(const std::string &muxState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleMuxStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleMuxStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         label
     )));
 }
@@ -244,8 +249,8 @@ void MuxPort::handleMuxConfig(const std::string &config)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleMuxConfigNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleMuxConfigNotification,
+        mLinkManagerStateMachinePtr.get(),
         mode
     )));
 }
@@ -261,8 +266,8 @@ void MuxPort::handleDefaultRouteState(const std::string &routeState)
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleDefaultRouteStateNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleDefaultRouteStateNotification,
+        mLinkManagerStateMachinePtr.get(),
         routeState
     )));
 }
@@ -278,8 +283,8 @@ void MuxPort::resetPckLossCount()
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::ActiveStandbyStateMachine::handleResetLinkProberPckLossCount,
-        &mLinkManagerStateMachine
+        &link_manager::LinkManagerStateMachineBase::handleResetLinkProberPckLossCount,
+        mLinkManagerStateMachinePtr.get()
     )));
 }
 

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -82,7 +82,8 @@ public:
         common::MuxConfig &muxConfig,
         const std::string &portName,
         uint16_t serverId,
-        boost::asio::io_service &ioService
+        boost::asio::io_service &ioService,
+        common::MuxPortConfig::PortCableType portCableType
     );
 
     /**
@@ -314,13 +315,13 @@ protected:
     friend class test::MuxManagerTest;
     friend class test::FakeMuxPort;
     /**
-    *@method getLinkManagerStateMachine
+    *@method getLinkManagerStateMachinePtr
     *
-    *@brief getter for ActiveStandbyStateMachine object (used during unit test)
+    *@brief getter for LinkManagerStateMachinePtr (used during unit test)
     *
-    *@return pointer to ActiveStandbyStateMachine object
+    *@return shared pointer to LinkManagerStateMachineBase object
     */
-    link_manager::ActiveStandbyStateMachine* getLinkManagerStateMachine() {return &mLinkManagerStateMachine;};
+    std::shared_ptr<link_manager::LinkManagerStateMachineBase> getLinkManagerStateMachinePtr() {return mLinkManagerStateMachinePtr;};
 
     /**
     *@method setComponentInitState
@@ -329,14 +330,14 @@ protected:
     *
     *@param component (in)  component index
     */
-    void setComponentInitState(uint8_t component) {mLinkManagerStateMachine.setComponentInitState(component);};
+    void setComponentInitState(uint8_t component) {mLinkManagerStateMachinePtr->setComponentInitState(component);};
 
 private:
     std::shared_ptr<mux::DbInterface> mDbInterfacePtr = nullptr;
     common::MuxPortConfig mMuxPortConfig;
     boost::asio::io_service::strand mStrand;
 
-    link_manager::ActiveStandbyStateMachine mLinkManagerStateMachine;
+    std::shared_ptr<link_manager::LinkManagerStateMachineBase> mLinkManagerStateMachinePtr;
 };
 
 } /* namespace mux */

--- a/src/common/MuxPortConfig.cpp
+++ b/src/common/MuxPortConfig.cpp
@@ -34,11 +34,13 @@ namespace common
 MuxPortConfig::MuxPortConfig(
     MuxConfig &muxConfig,
     const std::string &portName,
-    uint16_t serverId
+    uint16_t serverId,
+    PortCableType portCableType
 ) :
     mMuxConfig(muxConfig),
     mPortName(portName),
-    mServerId(serverId)
+    mServerId(serverId),
+    mPortCableType(portCableType)
 {
 }
 

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -53,6 +53,15 @@ public:
         Standby
     };
 
+    /**
+     * @enum PortCableType
+     * 
+     * @brief Port cable type
+     */
+    enum PortCableType {
+        ActiveStandby
+    };
+
 public:
     /**
     *@method MuxPortConfig
@@ -82,7 +91,8 @@ public:
     MuxPortConfig(
         MuxConfig &muxConfig,
         const std::string &portName,
-        uint16_t serverId
+        uint16_t serverId,
+        PortCableType portCableType = ActiveStandby
     );
 
     /**
@@ -251,6 +261,15 @@ public:
     */
     inline Mode getMode() const {return mMode;};
 
+    /**
+    *@method getPortCableType
+    *
+    *@brief getter for port cable type
+    *
+    *@return port cable type
+    */
+    inline PortCableType getPortCableType() const {return mPortCableType;};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;
@@ -258,6 +277,7 @@ private:
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;
+    PortCableType mPortCableType = ActiveStandby;
 };
 
 } /* namespace common */

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -82,9 +82,9 @@ ActiveStandbyStateMachine::ActiveStandbyStateMachine(
         {link_prober::LinkProberState::Label::Unknown, mux_state::MuxState::Label::Wait, link_state::LinkState::Label::Down}
     ),
     mMuxPortPtr(muxPortPtr),
-    mLinkProberStateMachine(*this, strand, muxPortConfig, ps(mCompositeState)),
-    mMuxStateMachine(*this, strand, muxPortConfig, ms(mCompositeState)),
-    mLinkStateMachine(*this, strand, muxPortConfig, ls(mCompositeState)),
+    mLinkProberStateMachine(this, strand, muxPortConfig, ps(mCompositeState)),
+    mMuxStateMachine(this, strand, muxPortConfig, ms(mCompositeState)),
+    mLinkStateMachine(this, strand, muxPortConfig, ls(mCompositeState)),
     mDeadlineTimer(strand.context()),
     mWaitTimer(strand.context())
 {

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -44,7 +44,8 @@ LinkManagerStateMachineBase::LinkManagerStateMachineBase(
     common::MuxPortConfig &muxPortConfig,
     CompositeState initialCompositeState)
     : StateMachine(strand, muxPortConfig),
-      mCompositeState(initialCompositeState) {
+      mCompositeState(initialCompositeState)
+{
 }
 
 //
@@ -52,7 +53,8 @@ LinkManagerStateMachineBase::LinkManagerStateMachineBase(
 //
 // initialize transition function table to NOOP functions
 //
-void LinkManagerStateMachineBase::initializeTransitionFunctionTable() {
+void LinkManagerStateMachineBase::initializeTransitionFunctionTable()
+{
     MUXLOGWARNING("Initialize State Transition Table With NO-OP...");
     for (uint8_t linkProberState = link_prober::LinkProberState::Label::Active;
          linkProberState < link_prober::LinkProberState::Label::Count;
@@ -72,8 +74,157 @@ void LinkManagerStateMachineBase::initializeTransitionFunctionTable() {
 //
 // NO-OP transition function
 //
-void LinkManagerStateMachineBase::noopTransitionFunction(CompositeState &nextState) {
+void LinkManagerStateMachineBase::noopTransitionFunction(CompositeState &nextState)
+{
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }
+
+//
+// ---> handleSwssBladeIpv4AddressUpdate(boost::asio::ip::address address);
+//
+// initialize LinkProber component. Note if this is the last component to be initialized,
+// state machine will be activated
+//
+void LinkManagerStateMachineBase::handleSwssBladeIpv4AddressUpdate(boost::asio::ip::address address)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
+//
+// handle get Server MAC address
+//
+void LinkManagerStateMachineBase::handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleGetMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle get MUX state notification
+//
+void LinkManagerStateMachineBase::handleGetMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleProbeMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle MUX state notification. Source of notification could be app_db via xcvrd
+//
+void LinkManagerStateMachineBase::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle MUX state notification
+//
+void LinkManagerStateMachineBase::handleMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleSwssLinkStateNotification(const link_state::LinkState::Label label);
+//
+// handle link state change notification
+//
+void LinkManagerStateMachineBase::handleSwssLinkStateNotification(const link_state::LinkState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+// ---> handlePeerLinkStateNotification(const link_state::LinkState::Label label);
+//
+// handle peer link state change notification
+//
+void LinkManagerStateMachineBase::handlePeerLinkStateNotification(const link_state::LinkState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleMuxConfigNotification(const common::MuxPortConfig::Mode mode);
+//
+// handle MUX configuration change notification
+//
+void LinkManagerStateMachineBase::handleMuxConfigNotification(const common::MuxPortConfig::Mode mode)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleSuspendTimerExpiry();
+//
+// handle suspend timer expiry notification from LinkProber
+//
+void LinkManagerStateMachineBase::handleSuspendTimerExpiry()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleSwitchActiveCommandCompletion();
+//
+// handle completion of sending switch command to peer ToR
+//
+void LinkManagerStateMachineBase::handleSwitchActiveCommandCompletion()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleSwitchActiveRequestEvent();
+//
+// handle switch active request from peer ToR
+//
+void LinkManagerStateMachineBase::handleSwitchActiveRequestEvent()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handleDefaultRouteStateNotification(const std::string &routeState);
+//
+// handle default route state notification from routeorch
+//
+void LinkManagerStateMachineBase::handleDefaultRouteStateNotification(const std::string &routeState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> handlePostPckLossRatioNotification(const uint64_t unknownEventCount, const uint64_t expectedPacketCount);
+//
+// handle post pck loss ratio
+//
+void LinkManagerStateMachineBase::handlePostPckLossRatioNotification(const uint64_t unknownEventCount, const uint64_t expectedPacketCount)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+// ---> handleResetLinkProberPckLossCount();
+//
+// reset link prober heartbeat packet loss count
+//
+void LinkManagerStateMachineBase::handleResetLinkProberPckLossCount()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+// ---> LinkManagerStateMachineBase::setComponentInitState(uint8_t component)
+//
+// set component inti state. This method is used for testing
+//
+void LinkManagerStateMachineBase::setComponentInitState(uint8_t component)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+};
 
 } /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -20,6 +20,7 @@
 #include <bitset>
 #include <boost/function.hpp>
 #include <functional>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -210,6 +211,164 @@ public:
      * @return const CompositeState& 
      */
     const CompositeState& getCompositeState() { return mCompositeState; };
+
+public:
+    /**
+    *@method handleSwssBladeIpv4AddressUpdate
+    *
+    *@brief initialize LinkProber component. Note if this is the last component to be initialized,
+    *       state machine will be activated
+    *
+    *@return none
+    */
+    virtual void handleSwssBladeIpv4AddressUpdate(boost::asio::ip::address address);
+
+    /**
+    *@method handleGetServerMacNotification
+    *
+    *@brief handle get Server MAC address
+    *
+    *@param address (in)    Server MAC address
+    *
+    *@return none
+    */
+    virtual void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
+
+    /**
+    *@method handleGetMuxStateNotification
+    *
+    *@brief handle get MUX state notification
+    *
+    *@param label (in)              new MuxState label
+    *
+    *@return none
+    */
+    virtual void handleGetMuxStateNotification(mux_state::MuxState::Label label);
+
+    /**
+    *@method handleProbeMuxStateNotification
+    *
+    *@brief handle probe MUX state notification
+    *
+    *@param label (in)              new MuxState label
+    *
+    *@return none
+    */
+    virtual void handleProbeMuxStateNotification(mux_state::MuxState::Label label);
+
+    /**
+    *@method handleMuxStateNotification
+    *
+    *@brief handle MUX state notification
+    *
+    *@param label (in)              new MuxState label
+    *
+    *@return none
+    */
+    virtual void handleMuxStateNotification(mux_state::MuxState::Label label);
+
+    /**
+    *@method handleSwssLinkStateNotification
+    *
+    *@brief handle link state change notification
+    *
+    *@param label (in)  new LinkState label
+    *
+    *@return none
+    */
+    virtual void handleSwssLinkStateNotification(const link_state::LinkState::Label label);
+
+    /**
+     * @method handlePeerLinkStateNotification
+     * 
+     * @brief handle peer link state notification
+     * 
+     * @param label (in) new peer link state label
+     * 
+     * @return none
+    */
+    virtual void handlePeerLinkStateNotification(const link_state::LinkState::Label label);
+
+    /**
+    *@method handleMuxConfigNotification
+    *
+    *@brief handle MUX configuration change notification
+    *
+    *@param mode (in)  new MUX config mode
+    *
+    *@return none
+    */
+    virtual void handleMuxConfigNotification(const common::MuxPortConfig::Mode mode);
+
+    /**
+    *@method handleSuspendTimerExpiry
+    *
+    *@brief handle suspend timer expiry notification from LinkProber
+    *
+    *@return none
+    */
+    virtual void handleSuspendTimerExpiry();
+
+    /**
+    *@method handleSwitchActiveCommandCompletion
+    *
+    *@brief handle completion of sending switch command to peer ToR
+    *
+    *@return none
+    */
+    virtual void handleSwitchActiveCommandCompletion();
+
+    /**
+    *@method handleSwitchActiveRequestEvent
+    *
+    *@brief handle switch active request from peer ToR
+    *
+    *@return none
+    */
+    virtual void handleSwitchActiveRequestEvent();
+
+    /**
+     * @method handleDefaultRouteStateNotification(const std::string &routeState)
+     * 
+     * @brief handle default route state notification from routeorch
+     * 
+     * @param routeState
+     * 
+     * @return none
+    */
+    virtual void handleDefaultRouteStateNotification(const std::string& routeState);
+
+    /**
+     * @method handlePostPckLossRatioNotification
+     * 
+     * @brief handle get post pck loss ratio 
+     * 
+     * @param unknownEventCount (in) count of missing icmp packets
+     * @param expectedPacketCount (in) count of expected icmp packets
+     * 
+     * @return none
+    */
+    virtual void handlePostPckLossRatioNotification(const uint64_t unknownEventCount, const uint64_t expectedPacketCount);
+
+    /**
+     * @method handleResetLinkProberPckLossCount
+     * 
+     * @brief reset link prober heartbeat packet loss count 
+     * 
+     * @return none
+    */
+    virtual void handleResetLinkProberPckLossCount();
+
+    /**
+    *@method setComponentInitState
+    *
+    *@brief set component inti state. This method is used for testing
+    *
+    *@param component (in)  component index
+    *
+    *@return none
+    */
+    virtual void setComponentInitState(uint8_t component);
 
 private:
     friend class ActiveStandbyStateMachine;

--- a/src/link_prober/LinkProberStateMachine.h
+++ b/src/link_prober/LinkProberStateMachine.h
@@ -31,6 +31,7 @@
 #include "link_prober/WaitState.h"
 
 namespace link_manager {
+class LinkManagerStateMachineBase;
 class ActiveStandbyStateMachine;
 } /* namespace link_manager */
 
@@ -131,13 +132,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
+    *@param linkManagerStateMachinePtr (in) pointer to LinkManagerStateMachineBase
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     LinkProberStateMachine(
-        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
+        link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         LinkProberState::Label label
@@ -352,7 +353,7 @@ private:
     static SwitchActiveRequestEvent mSwitchActiveRequestEvent;
 
 private:
-    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
+    link_manager::LinkManagerStateMachineBase *mLinkManagerStateMachinePtr;
     ActiveState mActiveState;
     StandbyState mStandbyState;
     UnknownState mUnknownState;

--- a/src/link_state/LinkStateMachine.cpp
+++ b/src/link_state/LinkStateMachine.cpp
@@ -38,7 +38,7 @@ DownEvent LinkStateMachine::mDownEvent;
 
 //
 // ---> LinkStateMachine(
-//          link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
+//          link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
 //          boost::asio::io_service::strand &strand,
 //          common::MuxPortConfig &muxPortConfig,
 //          LinkState::Label label
@@ -47,13 +47,13 @@ DownEvent LinkStateMachine::mDownEvent;
 // class constructor
 //
 LinkStateMachine::LinkStateMachine(
-    link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
+    link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
     boost::asio::io_service::strand &strand,
     common::MuxPortConfig &muxPortConfig,
     LinkState::Label label
 ) :
     common::StateMachine(strand, muxPortConfig),
-    mLinkManagerStateMachine(linkManagerStateMachine),
+    mLinkManagerStateMachinePtr(linkManagerStateMachinePtr),
     mUpState(*this, muxPortConfig),
     mDownState(*this, muxPortConfig)
 {
@@ -88,13 +88,13 @@ void LinkStateMachine::enterState(LinkState::Label label)
 inline
 void LinkStateMachine::postLinkManagerEvent(LinkState* linkState)
 {
-    boost::asio::io_service::strand &strand = mLinkManagerStateMachine.getStrand();
+    boost::asio::io_service::strand &strand = mLinkManagerStateMachinePtr->getStrand();
     boost::asio::io_service &ioService = strand.context();
     ioService.post(strand.wrap(boost::bind(
-        static_cast<void (link_manager::ActiveStandbyStateMachine::*) (link_manager::LinkStateEvent&, LinkState::Label)>
-            (&link_manager::ActiveStandbyStateMachine::handleStateChange),
-        &mLinkManagerStateMachine,
-        link_manager::ActiveStandbyStateMachine::getLinkStateEvent(),
+        static_cast<void (link_manager::LinkManagerStateMachineBase::*) (link_manager::LinkStateEvent&, LinkState::Label)>
+            (&link_manager::LinkManagerStateMachineBase::handleStateChange),
+        mLinkManagerStateMachinePtr,
+        link_manager::LinkManagerStateMachineBase::getLinkStateEvent(),
         linkState->getStateLabel()
     )));
 }

--- a/src/link_state/LinkStateMachine.h
+++ b/src/link_state/LinkStateMachine.h
@@ -29,7 +29,7 @@
 #include "UpState.h"
 
 namespace link_manager {
-class ActiveStandbyStateMachine;
+class LinkManagerStateMachineBase;
 } /* namespace link_manager */
 
 namespace link_state
@@ -85,13 +85,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
+    *@param linkManagerStateMachinePtr (in) pointer to LinkManagerStateMachineBase
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     LinkStateMachine(
-        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
+        link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         LinkState::Label label
@@ -192,7 +192,7 @@ private:
     static DownEvent mDownEvent;
 
 private:
-    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
+    link_manager::LinkManagerStateMachineBase *mLinkManagerStateMachinePtr;
     UpState mUpState;
     DownState mDownState;
 };

--- a/src/mux_state/MuxStateMachine.h
+++ b/src/mux_state/MuxStateMachine.h
@@ -32,7 +32,7 @@
 #include "mux_state/UnknownState.h"
 
 namespace link_manager {
-class ActiveStandbyStateMachine;
+class LinkManagerStateMachineBase;
 } /* namespace link_manager */
 
 namespace mux_state
@@ -110,13 +110,13 @@ public:
     *
     *@brief class constructor
     *
-    *@param linkManagerStateMachine (in)    reference to ActiveStandbyStateMachine
+    *@param linkManagerStateMachinePtr (in) pointer to LinkManagerStateMachineBase
     *@param strand (in)                     reference to boost serialization object
     *@param muxPortConfig (in)              reference to MuxPortConfig object
     *@param label (in)                      state machine initial state
     */
     MuxStateMachine(
-        link_manager::ActiveStandbyStateMachine &linkManagerStateMachine,
+        link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
         boost::asio::io_service::strand &strand,
         common::MuxPortConfig &muxPortConfig,
         MuxState::Label label
@@ -284,7 +284,7 @@ private:
     static ErrorEvent mErrorEvent;
 
 private:
-    link_manager::ActiveStandbyStateMachine &mLinkManagerStateMachine;
+    link_manager::LinkManagerStateMachineBase *mLinkManagerStateMachinePtr;
     ActiveState mActiveState;
     StandbyState mStandbyState;
     UnknownState mUnknownState;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -42,10 +42,14 @@ FakeMuxPort::FakeMuxPort(
         muxConfig,
         portName,
         serverId,
-        ioService
+        ioService,
+        common::MuxPortConfig::PortCableType::ActiveStandby
+    ),
+    mActiveStandbyStateMachinePtr(
+        std::dynamic_pointer_cast<link_manager::ActiveStandbyStateMachine>(getLinkManagerStateMachinePtr())
     ),
     mFakeLinkProber(
-        std::make_shared<FakeLinkProber> (&getLinkManagerStateMachine()->getLinkProberStateMachine())
+        std::make_shared<FakeLinkProber> (&mActiveStandbyStateMachinePtr->getLinkProberStateMachine())
     )
 {
     std::string prog_name = "linkmgrd-test";
@@ -53,25 +57,25 @@ FakeMuxPort::FakeMuxPort(
     common::MuxLogger::getInstance()->initialize(prog_name, log_filename, boost::log::trivial::debug);
     common::MuxLogger::getInstance()->setLevel(boost::log::trivial::trace);
     mMuxPortConfig.setMode(common::MuxPortConfig::Mode::Auto);
-    getLinkManagerStateMachine()->setInitializeProberFnPtr(
+    getActiveStandbyStateMachinePtr()->setInitializeProberFnPtr(
         boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())
     );
-    getLinkManagerStateMachine()->setStartProbingFnPtr(
+    getActiveStandbyStateMachinePtr()->setStartProbingFnPtr(
         boost::bind(&FakeLinkProber::startProbing, mFakeLinkProber.get())
     );
-    getLinkManagerStateMachine()->setUpdateEthernetFrameFnPtr(
+    getActiveStandbyStateMachinePtr()->setUpdateEthernetFrameFnPtr(
         boost::bind(&FakeLinkProber::updateEthernetFrame, mFakeLinkProber.get())
     );
-    getLinkManagerStateMachine()->setProbePeerTorFnPtr(
+    getActiveStandbyStateMachinePtr()->setProbePeerTorFnPtr(
         boost::bind(&FakeLinkProber::probePeerTor, mFakeLinkProber.get())
     );
-    getLinkManagerStateMachine()->setSuspendTxFnPtr(
+    getActiveStandbyStateMachinePtr()->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );
-    getLinkManagerStateMachine()->setResumeTxFnPtr(
+    getActiveStandbyStateMachinePtr()->setResumeTxFnPtr(
         boost::bind(&FakeLinkProber::resumeTxProbes, mFakeLinkProber.get())
     );
-    getLinkManagerStateMachine()->setSendPeerSwitchCommandFnPtr(
+    getActiveStandbyStateMachinePtr()->setSendPeerSwitchCommandFnPtr(
         boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
 }

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -31,31 +31,30 @@
 #include "FakeDbInterface.h"
 #include "FakeLinkProber.h"
 
-namespace test
-{
+namespace test {
 
-class FakeMuxPort: public ::mux::MuxPort
-{
+class FakeMuxPort : public ::mux::MuxPort {
 public:
     FakeMuxPort(
         std::shared_ptr<FakeDbInterface> dbInterface,
-        common::MuxConfig &muxConfig,
-        std::string &portName,
+        common::MuxConfig& muxConfig,
+        std::string& portName,
         uint16_t serverId,
-        boost::asio::io_service &ioService
-    );
+        boost::asio::io_service& ioService);
     virtual ~FakeMuxPort() = default;
 
     void activateStateMachine();
 
-    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() {return getLinkManagerStateMachine()->getCompositeState();};
-    link_prober::LinkProberStateMachine& getLinkProberStateMachine() {return getLinkManagerStateMachine()->getLinkProberStateMachine();};
-    mux_state::MuxStateMachine& getMuxStateMachine() {return getLinkManagerStateMachine()->getMuxStateMachine();};
-    link_state::LinkStateMachine& getLinkStateMachine() {return getLinkManagerStateMachine()->getLinkStateMachine();};
+    std::shared_ptr<link_manager::ActiveStandbyStateMachine> getActiveStandbyStateMachinePtr() { return mActiveStandbyStateMachinePtr; }
+    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getActiveStandbyStateMachinePtr()->getCompositeState(); };
+    link_prober::LinkProberStateMachine& getLinkProberStateMachine() { return getActiveStandbyStateMachinePtr()->getLinkProberStateMachine(); };
+    mux_state::MuxStateMachine& getMuxStateMachine() { return getActiveStandbyStateMachinePtr()->getMuxStateMachine(); };
+    link_state::LinkStateMachine& getLinkStateMachine() { return getActiveStandbyStateMachinePtr()->getLinkStateMachine(); };
 
-    bool getPendingMuxModeChange() {return getLinkManagerStateMachine()->mPendingMuxModeChange;};
-    common::MuxPortConfig::Mode getTargetMuxMode() {return getLinkManagerStateMachine()->mTargetMuxMode;};
+    bool getPendingMuxModeChange() { return getActiveStandbyStateMachinePtr()->mPendingMuxModeChange; };
+    common::MuxPortConfig::Mode getTargetMuxMode() { return getActiveStandbyStateMachinePtr()->mTargetMuxMode; };
 
+    std::shared_ptr<link_manager::ActiveStandbyStateMachine> mActiveStandbyStateMachinePtr;
     std::shared_ptr<FakeLinkProber> mFakeLinkProber;
 };
 

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -57,7 +57,7 @@ public:
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getTorMacAddress(std::string port);
     void processMuxPortConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
-    link_manager::ActiveStandbyStateMachine::CompositeState getCompositeStateMachineState(std::string port);
+    link_manager::LinkManagerStateMachineBase::CompositeState getCompositeStateMachineState(std::string port);
     void processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
     void processServerMacAddress(std::string port, std::array<char, MAX_ADDR_SIZE + 1> ip, std::array<char, MAX_ADDR_SIZE + 1> mac);
     void processLoopback2InterfaceInfo(std::vector<std::string> &loopbackIntfs);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To support per-port `cable_typ` inside `MUX_CABLE` table to select the corresponding different state machine for the port.

#### How did you do it?
1. Add `getPortCableType` to collect port cable types before adding the ports, the port cable types will be stored inside `MuxManager` object, and during `MuxPort` creation in `getMuxPortPtrOrThrow`, those port types will be passed to `MuxPort` to select the correct state machine to use.
2. Put those event handlers in `ActiveStandbyStateMachine` into `LinkManagerStateMachineBase` as virtual functions.
3. Let `MuxPort` use a pointer to `LinkManagerStateMachineBase`.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->