### PR TITLE
Collect port cable type to use corresponding state machine

### DIFF
--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -414,6 +414,28 @@ private:
     void getServerIpAddress(std::shared_ptr<swss::DBConnector> configDbConnector);
 
     /**
+    *@method processPortCableType
+    *
+    *@brief process port cable type and build a map of port name to cable type
+    *
+    *@param entries   config_db MUX_CABLE entries
+    *
+    *@return none
+    */
+    inline void processPortCableType(std::vector<swss::KeyOpFieldsValuesTuple> &entries);
+
+   /**
+    *@method getPortCableType
+    *
+    *@brief retrieve per port cable type
+    *
+    *@param configDbConnector   config db connector
+    *
+    *@return none
+    */
+    void getPortCableType(std::shared_ptr<swss::DBConnector> configDbConnector);
+
+    /**
     *@method processMuxPortConfigNotifiction
     *
     *@brief process MUX port configuration change notification

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -160,6 +160,29 @@ void MuxManager::updateMuxPortConfig(const std::string &portName, const std::str
     }
 }
 
+//
+// ---> updatePortCableType(const std::string &portName, const std::string &cableType);
+//
+// update port cable type
+//
+void MuxManager::updatePortCableType(const std::string &portName, const std::string &cableType)
+{
+    MUXLOGWARNING(boost::format("%s: Port cable type: %s") % portName % cableType);
+
+    common::MuxPortConfig::PortCableType portCableType;
+    if (cableType == "active-standby") {
+        portCableType = common::MuxPortConfig::PortCableType::ActiveStandby;
+    } else {
+        MUXLOGERROR(
+            boost::format(
+                "%s: Received unsupported port cable type %s, fall back to active-standby!"
+            ) % portName % cableType
+        );
+        portCableType = common::MuxPortConfig::PortCableType::ActiveStandby;
+    }
+    mPortCableTypeMap.insert(PortCableTypeMap::value_type(portName, portCableType));
+}
+
 // 
 // ---> resetPckLossCount(const std::string &portName);
 //
@@ -308,7 +331,8 @@ std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &por
                 mMuxConfig,
                 portName,
                 serverId,
-                mIoService
+                mIoService,
+                mPortCableTypeMap.at(portName)
             );
             mPortMap.insert({portName, muxPortPtr});
         }

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -32,6 +32,7 @@
 
 #include "MuxPort.h"
 #include "common/MuxConfig.h"
+#include "common/MuxPortConfig.h"
 #include "DbInterface.h"
 
 namespace test {
@@ -42,6 +43,9 @@ namespace mux
 {
 using PortMap = std::map<std::string, std::shared_ptr<MuxPort>>;
 using PortMapIterator = PortMap::iterator;
+
+using PortCableTypeMap = std::map<std::string, common::MuxPortConfig::PortCableType>;
+using PortCableTypeMapIterator = PortCableTypeMap::iterator;
 
 /**
  *@class MuxManager
@@ -245,6 +249,18 @@ public:
     */
     void updateMuxPortConfig(const std::string &portName, const std::string &linkState);
 
+   /**
+    *@method updatePortCableType
+    *
+    *@brief update port cable type
+    *
+    *@param portName (in)   port name
+    *@param cableType (in)  port cable type
+    *
+    *@return none
+    */
+    void updatePortCableType(const std::string &portName, const std::string &cableType);
+
     /**
      * @method resetPckLossCount
      * 
@@ -396,6 +412,7 @@ private:
     std::shared_ptr<mux::DbInterface> mDbInterfacePtr;
 
     PortMap mPortMap;
+    PortCableTypeMap mPortCableTypeMap;
 
     std::string mIpv4DefaultRouteState = "na";
     std::string mIpv6DefaultRouteState = "na";

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -82,7 +82,8 @@ public:
         common::MuxConfig &muxConfig,
         const std::string &portName,
         uint16_t serverId,
-        boost::asio::io_service &ioService
+        boost::asio::io_service &ioService,
+        common::MuxPortConfig::PortCableType portCableType
     );
 
     /**

--- a/src/common/MuxPortConfig.cpp
+++ b/src/common/MuxPortConfig.cpp
@@ -34,11 +34,13 @@ namespace common
 MuxPortConfig::MuxPortConfig(
     MuxConfig &muxConfig,
     const std::string &portName,
-    uint16_t serverId
+    uint16_t serverId,
+    PortCableType portCableType
 ) :
     mMuxConfig(muxConfig),
     mPortName(portName),
-    mServerId(serverId)
+    mServerId(serverId),
+    mPortCableType(portCableType)
 {
 }
 

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -53,6 +53,15 @@ public:
         Standby
     };
 
+    /**
+     * @enum PortCableType
+     * 
+     * @brief Port cable type
+     */
+    enum PortCableType {
+        ActiveStandby
+    };
+
 public:
     /**
     *@method MuxPortConfig
@@ -82,7 +91,8 @@ public:
     MuxPortConfig(
         MuxConfig &muxConfig,
         const std::string &portName,
-        uint16_t serverId
+        uint16_t serverId,
+        PortCableType portCableType
     );
 
     /**
@@ -251,6 +261,15 @@ public:
     */
     inline Mode getMode() const {return mMode;};
 
+    /**
+    *@method getPortCableType
+    *
+    *@brief getter for port cable type
+    *
+    *@return port cable type
+    */
+    inline PortCableType getPortCableType() const {return mPortCableType;};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;
@@ -258,6 +277,7 @@ private:
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;
+    PortCableType mPortCableType;
 };
 
 } /* namespace common */

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -42,7 +42,8 @@ FakeMuxPort::FakeMuxPort(
         muxConfig,
         portName,
         serverId,
-        ioService
+        ioService,
+        common::MuxPortConfig::PortCableType::ActiveStandby
     ),
     mActiveStandbyStateMachinePtr(
         std::dynamic_pointer_cast<link_manager::ActiveStandbyStateMachine>(getLinkManagerStateMachinePtr())

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -56,6 +56,7 @@ public:
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getTorMacAddress(std::string port);
+    common::MuxPortConfig::PortCableType getPortCableType(const std::string &port);
     void processMuxPortConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     link_manager::LinkManagerStateMachineBase::CompositeState getCompositeStateMachineState(std::string port);
     void processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
@@ -66,6 +67,7 @@ public:
     void processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     void updateServerMacAddress(boost::asio::ip::address serverIp, const uint8_t *serverMac);
     void processGetMuxState(const std::string &portName, const std::string &muxState);
+    void updatePortCableType(const std::string &port, const std::string &cableType);
     void createPort(std::string port);
 
 public:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Let `MuxManager` collect per-port cable type info from `MUX_PORT` table, and init corresponding state machine.

#### How did you do it?
During the db interface thread method `handleSwssNotification`, call `getPortCableType` to collect per-port cable type info and store in `MuxManager`, so the creation of `MuxPort` could choose the state machine based on the cable type.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->