### PR TITLE
Prevent switching MUX to "Unknown"

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -592,7 +592,8 @@ void ActiveStandbyStateMachine::handleGetMuxStateNotification(mux_state::MuxStat
 
     if (mComponentInitState.all() && ms(mCompositeState) != label &&
         ms(mCompositeState) != mux_state::MuxState::Wait &&
-        ms(mCompositeState) != mux_state::MuxState::Error) {
+        ms(mCompositeState) != mux_state::MuxState::Error &&
+        ms(mCompositeState) != mux_state::MuxState::Unknown) {
         // notify swss of mux state change
         MUXLOGWARNING(boost::format("%s: Switching MUX state from '%s' to '%s' to match linkmgrd/xcvrd state") %
             mMuxPortConfig.getPortName() %

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -893,6 +893,20 @@ TEST_F(LinkManagerStateMachineTest, ProberWaitMuxUnknownLinkDown)
 
 }
 
+TEST_F(LinkManagerStateMachineTest, MuxUnknownGetMuxStateActive)
+{
+    setMuxActive();
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    handleProbeMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    // even get mux state "active" in state db, which is mismatching from "unknown", LinkManager shouldn't switch to "unknown"
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    handleGetMuxState("active", 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+}
+
 TEST_F(LinkManagerStateMachineTest, MuxActive2Error2Active)
 {
     setMuxActive();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is to fix the issue that linkmgrd writes `unknown` to app db, or in other words, switches MUX to unknown, which can only be triggered by state db mismatching LinkManager mux state. 

```
~$ sudo show mux metrics Ethernet116 
PORT         EVENT                          TIME
-----------  -----------------------------  ---------------------------
Ethernet116  linkmgrd_switch_unknown_start  2022-Mar-07 23:56:48.865163
```

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Switching to `unknown` doesn't make sense, and can cause confusion. 

#### How did you do it?

#### How did you verify/test it?
Tested on virtual testbed. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->