### PR TITLE
Add port cable type getter for `MuxManager`

### DIFF
--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -314,6 +314,20 @@ void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &rou
 }
 
 //
+// ---> getMuxPortCableType(const std::string &portName);
+//
+// retrieve the mux port cable type for port
+//
+inline common::MuxPortConfig::PortCableType MuxManager::getMuxPortCableType(const std::string &portName)
+{
+    PortCableTypeMapIterator portCableTypeIter = mPortCableTypeMap.find(portName);
+    if (portCableTypeIter == mPortCableTypeMap.end()) {
+        mPortCableTypeMap.insert({portName, common::MuxPortConfig::PortCableType::DefaultType});
+    }
+    return mPortCableTypeMap[portName];
+}
+
+//
 // ---> getMuxPortPtrOrThrow(const std::string &portName);
 //
 // retrieve a pointer to MuxPort if it exist or create a new MuxPort object
@@ -321,6 +335,7 @@ void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &rou
 std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &portName)
 {
     std::shared_ptr<MuxPort> muxPortPtr;
+    common::MuxPortConfig::PortCableType muxPortCableType = getMuxPortCableType(portName);
 
     try {
         PortMapIterator portMapIterator = mPortMap.find(portName);
@@ -332,7 +347,7 @@ std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &por
                 portName,
                 serverId,
                 mIoService,
-                mPortCableTypeMap.at(portName)
+                muxPortCableType
             );
             mPortMap.insert({portName, muxPortPtr});
         }

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -359,6 +359,17 @@ public:
 
 private:
     /**
+    *@method getMuxPortCableType
+    *
+    *@brief retrieve the mux port cable type for port
+    *
+    *@param portName (in)   Mux port name
+    *
+    *@return port cable type
+    */
+    inline common::MuxPortConfig::PortCableType getMuxPortCableType(const std::string &portName);
+
+    /**
     *@method getMuxPortPtrOrThrow
     *
     *@brief retrieve a pointer to MuxPort if it exist or create a new MuxPort object

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -59,7 +59,9 @@ public:
      * @brief Port cable type
      */
     enum PortCableType {
-        ActiveStandby
+        ActiveStandby,
+        ActiveActive,
+        DefaultType = ActiveStandby
     };
 
 public:


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
If a port is not in the `MUX_CABLE` table, `linkmgrd` still receives link up state, and calls `addOrUpdateMuxPortLinkState` to try to create a `MuxPort` object, in this case, the creation will fail due to the not-existed port cable type entry in the port cable type map.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Add a getter `getMuxPortCableType` to `MuxManager`, if the port cable type map doesn't have an entry, set it with the default port cable mode `active-standby`

#### How did you verify/test it?
`linkmgrd` functions without error on a dualtor setup testbed.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->