### PR TITLE
[link_prober] Add peer link prober event and state

### DIFF
--- a/src/link_prober/LinkProberState.cpp
+++ b/src/link_prober/LinkProberState.cpp
@@ -21,6 +21,7 @@
  *      Author: Tamer Ahmed
  */
 
+#include "common/MuxLogger.h"
 
 #include <link_prober/LinkProberState.h>
 #include <link_prober/LinkProberStateMachine.h>
@@ -42,6 +43,41 @@ LinkProberState::LinkProberState(
         muxPortConfig
     )
 {
+}
+
+LinkProberState* LinkProberState::handleEvent(IcmpPeerEvent &event)
+{
+    MUXLOGERROR(getMuxPortConfig().getPortName());
+
+    return nullptr;
+}
+
+LinkProberState* LinkProberState::handleEvent(IcmpSelfEvent &event)
+{
+    MUXLOGERROR(getMuxPortConfig().getPortName());
+
+    return nullptr;
+}
+
+LinkProberState* LinkProberState::handleEvent(IcmpUnknownEvent &event)
+{
+    MUXLOGERROR(getMuxPortConfig().getPortName());
+
+    return nullptr;
+}
+
+LinkProberState* LinkProberState::handleEvent(IcmpPeerActiveEvent &event)
+{
+    MUXLOGERROR(getMuxPortConfig().getPortName());
+
+    return nullptr;
+}
+
+LinkProberState* LinkProberState::handleEvent(IcmpPeerUnknownEvent &event)
+{
+    MUXLOGERROR(getMuxPortConfig().getPortName());
+
+    return nullptr;
 }
 
 } /* namespace link_prober */

--- a/src/link_prober/LinkProberState.h
+++ b/src/link_prober/LinkProberState.h
@@ -33,6 +33,8 @@ class IcmpPeerEvent;
 class IcmpSelfEvent;
 class IcmpUnknownEvent;
 class SuspendTimerExpiredEvent;
+class IcmpPeerActiveEvent;
+class IcmpPeerUnknownEvent;
 
 /**
  *@class LinkProberState
@@ -102,7 +104,7 @@ public:
     *
     *@return pointer to next LinkProberState
     */
-    virtual LinkProberState* handleEvent(IcmpPeerEvent &event) = 0;
+    virtual LinkProberState* handleEvent(IcmpPeerEvent &event);
 
     /**
     *@method handleEvent
@@ -113,7 +115,7 @@ public:
     *
     *@return pointer to next LinkProberState
     */
-    virtual LinkProberState* handleEvent(IcmpSelfEvent &event) = 0;
+    virtual LinkProberState* handleEvent(IcmpSelfEvent &event);
 
     /**
     *@method handleEvent
@@ -124,7 +126,29 @@ public:
     *
     *@return pointer to next LinkProberState
     */
-    virtual LinkProberState* handleEvent(IcmpUnknownEvent &event) = 0;
+    virtual LinkProberState* handleEvent(IcmpUnknownEvent &event);
+
+    /**
+    *@method handleEvent
+    *
+    *@brief handle IcmpPeerActiveEvent from LinkProber
+    *
+    *@param event (in)  reference to IcmpPeerActiveEvent
+    *
+    *@return pointer to next LinkProberState
+    */
+    virtual LinkProberState* handleEvent(IcmpPeerActiveEvent &event);
+
+    /**
+    *@method handleEvent
+    *
+    *@brief handle IcmpPeerUnknownEvent from LinkProber
+    *
+    *@param event (in)  reference to IcmpPeerUnknownEvent
+    *
+    *@return pointer to next LinkProberState
+    */
+    virtual LinkProberState* handleEvent(IcmpPeerUnknownEvent &event);
 
     /**
     *@method getStateLabel

--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -33,6 +33,8 @@ IcmpUnknownEvent LinkProberStateMachineBase::mIcmpUnknownEvent;
 SuspendTimerExpiredEvent LinkProberStateMachineBase::mSuspendTimerExpiredEvent;
 SwitchActiveCommandCompleteEvent LinkProberStateMachineBase::mSwitchActiveCommandCompleteEvent;
 SwitchActiveRequestEvent LinkProberStateMachineBase::mSwitchActiveRequestEvent;
+IcmpPeerActiveEvent LinkProberStateMachineBase::mIcmpPeerActiveEvent;
+IcmpPeerUnknownEvent LinkProberStateMachineBase::mIcmpPeerUnknownEvent;
 
 LinkProberStateMachineBase::LinkProberStateMachineBase(
     link_manager::LinkManagerStateMachineBase *linkManagerStateMachinePtr,
@@ -44,7 +46,9 @@ LinkProberStateMachineBase::LinkProberStateMachineBase(
     mActiveState(*this, muxPortConfig),
     mStandbyState(*this, muxPortConfig),
     mUnknownState(*this, muxPortConfig),
-    mWaitState(*this, muxPortConfig)
+    mWaitState(*this, muxPortConfig),
+    mPeerActiveState(*this, muxPortConfig),
+    mPeerUnknownState(*this, muxPortConfig)
 {
 }
 
@@ -58,12 +62,11 @@ void LinkProberStateMachineBase::postLinkProberStateEvent(E &e)
 {
     boost::asio::io_service::strand &strand = getStrand();
     boost::asio::io_service &ioService = strand.context();
-    ioService.post(strand.wrap(boost::bind(
-        static_cast<void (LinkProberStateMachineBase::*) (decltype(e))>
-            (&LinkProberStateMachineBase::processEvent<decltype(e)>),
-        this,
-        e
-    )));
+    ioService.post(
+        strand.wrap(
+            [this, &e]() { processEvent(e); }
+        )
+    );
 }
 
 //
@@ -89,6 +92,22 @@ void LinkProberStateMachineBase::postLinkProberStateEvent<IcmpPeerEvent>(IcmpPee
 //
 template
 void LinkProberStateMachineBase::postLinkProberStateEvent<IcmpUnknownEvent>(IcmpUnknownEvent &event);
+
+//
+// ---> LinkProberStateMachineBase::postLinkProberStateEvent(IcmpPeerActiveEvent &e);
+//
+// post LinkProberState IcmpPeerActiveEvent to the state machine
+//
+template
+void LinkProberStateMachineBase::postLinkProberStateEvent<IcmpPeerActiveEvent>(IcmpPeerActiveEvent &event);
+
+//
+// ---> LinkProberStateMachineBase::postLinkProberStateEvent(IcmpPeerUnknownEvent &e);
+//
+// post LinkProberState IcmpPeerUnknownEvent to the state machine
+//
+template
+void LinkProberStateMachineBase::postLinkProberStateEvent<IcmpPeerUnknownEvent>(IcmpPeerUnknownEvent &event);
 
 //
 // ---> LinkProberStateMachineBase::processEvent(T &t);
@@ -137,7 +156,27 @@ void LinkProberStateMachineBase::processEvent<IcmpUnknownEvent&>(IcmpUnknownEven
 //
 void LinkProberStateMachineBase::processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent)
 {
-    MUXLOGINFO(mMuxPortConfig.getPortName());
+    MUXLOGERROR(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> processEvent(IcmpPeerActiveEvent &suspendTimerExpiredEvent);
+//
+// process LinkProberState suspend timer expiry event
+//
+void LinkProberStateMachineBase::processEvent(IcmpPeerActiveEvent &icmpPeerActiveEvent)
+{
+    MUXLOGERROR(mMuxPortConfig.getPortName());
+}
+
+//
+// ---> processEvent(IcmpPeerUnknownEvent &suspendTimerExpiredEvent);
+//
+// process LinkProberState suspend timer expiry event
+//
+void LinkProberStateMachineBase::processEvent(IcmpPeerUnknownEvent &icmpPeerUnknownEvent)
+{
+    MUXLOGERROR(mMuxPortConfig.getPortName());
 }
 
 //
@@ -147,7 +186,7 @@ void LinkProberStateMachineBase::processEvent(SuspendTimerExpiredEvent &suspendT
 //
 void LinkProberStateMachineBase::processEvent(SwitchActiveCommandCompleteEvent &switchActiveCommandCompleteEvent)
 {
-    MUXLOGINFO(mMuxPortConfig.getPortName());
+    MUXLOGERROR(mMuxPortConfig.getPortName());
 }
 
 //
@@ -157,7 +196,7 @@ void LinkProberStateMachineBase::processEvent(SwitchActiveCommandCompleteEvent &
 //
 void LinkProberStateMachineBase::processEvent(SwitchActiveRequestEvent &switchActiveRequestEvent)
 {
-    MUXLOGINFO(mMuxPortConfig.getPortName());
+    MUXLOGERROR(mMuxPortConfig.getPortName());
 }
 
 //
@@ -167,7 +206,7 @@ void LinkProberStateMachineBase::processEvent(SwitchActiveRequestEvent &switchAc
 //
 void LinkProberStateMachineBase::handleMackAddressUpdate(const std::array<uint8_t, ETHER_ADDR_LEN> address)
 {
-    MUXLOGINFO(mMuxPortConfig.getPortName());
+    MUXLOGERROR(mMuxPortConfig.getPortName());
 }
 
 //
@@ -177,7 +216,7 @@ void LinkProberStateMachineBase::handleMackAddressUpdate(const std::array<uint8_
 //
 void LinkProberStateMachineBase::handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount)
 {
-    MUXLOGINFO(mMuxPortConfig.getPortName());
+    MUXLOGERROR(mMuxPortConfig.getPortName());
 }
 
 //

--- a/src/link_prober/LinkProberStateMachineBase.h
+++ b/src/link_prober/LinkProberStateMachineBase.h
@@ -18,6 +18,8 @@
 
 #include "common/StateMachine.h"
 #include "link_prober/ActiveState.h"
+#include "link_prober/PeerActiveState.h"
+#include "link_prober/PeerUnknownState.h"
 #include "link_prober/StandbyState.h"
 #include "link_prober/UnknownState.h"
 #include "link_prober/WaitState.h"
@@ -52,6 +54,7 @@ public:
     IcmpPeerEvent() = default;
     ~IcmpPeerEvent() = default;
 };
+
 /**
  *@class IcmpUnknownEvent
  *
@@ -62,6 +65,30 @@ class IcmpUnknownEvent
 public:
     IcmpUnknownEvent() = default;
     ~IcmpUnknownEvent() = default;
+};
+
+/**
+ *@class IcmpPeerActiveEvent
+ *
+ *@brief signals a IcmpPeerActiveEvent event to LinkProber state machine
+ */
+class IcmpPeerActiveEvent
+{
+public:
+    IcmpPeerActiveEvent() = default;
+    ~IcmpPeerActiveEvent() = default;
+};
+
+/**
+ *@class IcmpPeerUnknownEvent
+ *
+ *@brief signals a IcmpPeerUnknownEvent event to LinkProber state machine
+ */
+class IcmpPeerUnknownEvent
+{
+public:
+    IcmpPeerUnknownEvent() = default;
+    ~IcmpPeerUnknownEvent() = default;
 };
 
 /**
@@ -187,6 +214,28 @@ public:
     /**
      *@method processEvent
      *
+     *@brief process IcmpPeerActiveEvent
+     *
+     *@param icmpPeerActiveEvent (in)  reference to the IcmpPeerActiveEvent event
+     *
+     *@return none
+     */
+    virtual void processEvent(IcmpPeerActiveEvent &icmpPeerActiveEvent);
+
+    /**
+     *@method processEvent
+     *
+     *@brief process IcmpPeerUnknownEvent
+     *
+     *@param icmpPeerUnknownEvent (in)  reference to the IcmpPeerUnknownEvent event
+     *
+     *@return none
+     */
+    virtual void processEvent(IcmpPeerUnknownEvent &icmpPeerUnknownEvent);
+
+    /**
+     *@method processEvent
+     *
      *@brief process LinkProberState suspend timer expiry event
      *
      *@param suspendTimerExpiredEvent (in)  reference to the SuspendTimerExpiredEvent event
@@ -277,6 +326,24 @@ public:
     */
     WaitState* getWaitState() {return &mWaitState;};
 
+    /**
+    *@method getPeerActiveState
+    *
+    *@brief getter for PeerActiveState object
+    *
+    *@return pointer to PeerActiveState object
+    */
+    PeerActiveState* getPeerActiveState() {return &mPeerActiveState;};
+
+    /**
+    *@method getPeerUnknownState
+    *
+    *@brief getter for PeerUnknownState object
+    *
+    *@return pointer to PeerUnknownState object
+    */
+    PeerUnknownState* getPeerUnknownState() {return &mPeerUnknownState;};
+
 public:
     /**
      *@method getIcmpSelfEvent
@@ -332,6 +399,24 @@ public:
      */
     static SwitchActiveRequestEvent &getSwitchActiveRequestEvent() { return mSwitchActiveRequestEvent; };
 
+    /**
+     *@method getIcmpPeerActiveEvent
+     *
+     *@brief getter for IcmpPeerActiveEvent object
+     *
+     *@return pointer to IcmpPeerActiveEvent object
+     */
+    static IcmpPeerActiveEvent &getIcmpPeerActiveEvent() { return mIcmpPeerActiveEvent; }
+
+    /**
+     *@method getIcmpPeerUnknownEvent
+     *
+     *@brief getter for IcmpPeerUnknownEvent object
+     *
+     *@return pointer to IcmpPeerUnknownEvent object
+     */
+    static IcmpPeerUnknownEvent &getIcmpPeerUnknownEvent() { return mIcmpPeerUnknownEvent; }
+
 private:
     /**
      *@method postLinkManagerEvent
@@ -351,6 +436,8 @@ private:
     static SuspendTimerExpiredEvent mSuspendTimerExpiredEvent;
     static SwitchActiveCommandCompleteEvent mSwitchActiveCommandCompleteEvent;
     static SwitchActiveRequestEvent mSwitchActiveRequestEvent;
+    static IcmpPeerActiveEvent mIcmpPeerActiveEvent;
+    static IcmpPeerUnknownEvent mIcmpPeerUnknownEvent;
 
 private:
     friend class LinkProberStateMachine;
@@ -361,6 +448,8 @@ private:
     StandbyState mStandbyState;
     UnknownState mUnknownState;
     WaitState mWaitState;
+    PeerActiveState mPeerActiveState;
+    PeerUnknownState mPeerUnknownState;
 };
 } // namespace link_prober
 

--- a/src/link_prober/PeerActiveState.cpp
+++ b/src/link_prober/PeerActiveState.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "link_prober/PeerActiveState.h"
+#include "link_prober/PeerUnknownState.h"
+#include "link_prober/LinkProberStateMachine.h"
+
+#include "common/MuxLogger.h"
+
+namespace link_prober
+{
+
+//
+// ---> PeerActiveState(LinkProberStateMachineBase &stateMachine, common::MuxPortConfig &muxPortConfig);
+//
+// class constructor
+//
+PeerActiveState::PeerActiveState(
+    LinkProberStateMachineBase &stateMachine,
+    common::MuxPortConfig &muxPortConfig
+) :
+    LinkProberState(stateMachine, muxPortConfig)
+{
+}
+
+//
+// ---> handleEvent(IcmpPeerActiveEvent &event);
+//
+// handle IcmpPeerActiveEvent from LinkProber
+//
+LinkProberState* PeerActiveState::handleEvent(IcmpPeerActiveEvent &event)
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *> (getStateMachine());
+    LinkProberState *nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerActiveState());
+
+    resetState();
+
+    return nextState;
+}
+
+//
+// ---> handleEvent(IcmpPeerUnknownEvent &event);
+//
+// handle IcmpPeerUnknownEvent from LinkProber
+//
+LinkProberState* PeerActiveState::handleEvent(IcmpPeerUnknownEvent &event)
+{
+    LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *> (getStateMachine());
+    LinkProberState *nextState;
+
+    if (++mUnknownEventCount >= getMuxPortConfig().getNegativeStateChangeRetryCount()) {
+        nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerUnknownState());
+    }
+    else {
+        nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerActiveState());
+    }
+
+    return nextState;
+}
+
+//
+// ---> resetState();
+//
+// reset current state attributes
+//
+void PeerActiveState::resetState()
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    mUnknownEventCount = 0;
+}
+
+} /* namespace link_prober */

--- a/src/link_prober/PeerActiveState.h
+++ b/src/link_prober/PeerActiveState.h
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINK_PROBER_PEERACTIVESTATE_H_
+#define LINK_PROBER_PEERACTIVESTATE_H_
+
+#include "LinkProberState.h"
+
+namespace link_prober
+{
+class LinkProberStateMachineBase;
+
+/**
+ *@class PeerActiveState
+ *
+ *@brief maintains peer Active state of LinkProber
+ */
+class PeerActiveState : public LinkProberState {
+public:
+    /**
+     *@method PeerActiveState
+     *
+     *@brief class default constructor
+     */
+    PeerActiveState() = delete;
+
+    /**
+     *@method PeerActiveState
+     *
+     *@brief class copy constructor
+     *
+     *@param ActiveState (in)  reference to PeerActiveState object to be copied
+     */
+    PeerActiveState(const PeerActiveState &) = delete;
+
+    /**
+     *@method PeerActiveState
+     *
+     *@brief class constructor
+     *
+     *@param stateMachine (in)   reference to LinkProberStateMachineBase
+     *@param muxPortConfig (in)  reference to MuxPortConfig object
+     */
+    PeerActiveState(
+        LinkProberStateMachineBase &stateMachine,
+        common::MuxPortConfig &muxPortConfig
+    );
+
+    /**
+     *@method ~PeerActiveState
+     *
+     *@brief class destructor
+     */
+    virtual ~PeerActiveState() = default;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerActiveEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerActiveEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerActiveEvent &event) override;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerUnknownEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerUnknownEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerUnknownEvent &event) override;
+
+    /**
+     *@method resetState
+     *
+     *@brief reset current state attributes
+     *
+     *@return none
+     */
+    virtual void resetState() override;
+
+    /**
+     *@method getStateLabel
+     *
+     *@brief getter for LinkeProberState label
+     *
+     *@return LinkProberState Active label
+     */
+    virtual LinkProberState::Label getStateLabel() override { return LinkProberState::Label::Active; };
+
+private:
+    uint8_t mUnknownEventCount = 0;
+};
+
+} /* namespace link_prober */
+
+#endif /* LINK_PROBER_PEERACTIVESTATE_H_ */

--- a/src/link_prober/PeerUnknownState.cpp
+++ b/src/link_prober/PeerUnknownState.cpp
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "link_prober/PeerActiveState.h"
+#include "link_prober/PeerUnknownState.h"
+#include "link_prober/LinkProberStateMachine.h"
+
+#include "common/MuxLogger.h"
+
+namespace link_prober
+{
+
+//
+// ---> PeerUnknownState(LinkProberStateMachineBase &stateMachine, common::MuxPortConfig &muxPortConfig);
+//
+// class constructor
+//
+PeerUnknownState::PeerUnknownState(
+    LinkProberStateMachineBase &stateMachine,
+    common::MuxPortConfig &muxPortConfig
+) :
+    LinkProberState(stateMachine, muxPortConfig)
+{
+}
+
+//
+// ---> handleEvent(IcmpPeerActiveEvent &event);
+//
+// handle IcmpPeerActiveEvent from LinkProber
+//
+LinkProberState* PeerUnknownState::handleEvent(IcmpPeerActiveEvent &event)
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    LinkProberStateMachineBase *stateMachine =
+        dynamic_cast<LinkProberStateMachineBase *> (getStateMachine());
+    LinkProberState *nextState;
+
+    if (++mPeerEventCount >= getMuxPortConfig().getPositiveStateChangeRetryCount()) {
+        nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerActiveState());
+    }
+    else {
+        nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerUnknownState());
+    }
+
+    return nextState;
+}
+
+//
+// ---> handleEvent(IcmpPeerUnknownEvent &event);
+//
+// handle IcmpPeerUnknownEvent from LinkProber
+//
+LinkProberState* PeerUnknownState::handleEvent(IcmpPeerUnknownEvent &event)
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *> (getStateMachine());
+    LinkProberState *nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerUnknownState());
+
+    resetState();
+
+    return nextState;
+}
+
+//
+// ---> resetState();
+//
+// reset current state attributes
+//
+void PeerUnknownState::resetState()
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    mPeerEventCount = 0;
+}
+
+} /* namespace link_prober */

--- a/src/link_prober/PeerUnknownState.h
+++ b/src/link_prober/PeerUnknownState.h
@@ -1,0 +1,117 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINK_PROBER_PEERUNKNOWNSTATE_H_
+#define LINK_PROBER_PEERUNKNOWNSTATE_H_
+
+#include <stdint.h>
+
+#include "LinkProberState.h"
+
+namespace link_prober
+{
+class LinkProberStateMachineBase;
+
+/**
+ *@class PeerUnknownState
+ *
+ *@brief maintains peer Unknown state of LinkProber
+ */
+class PeerUnknownState : public LinkProberState {
+public:
+    /**
+     *@method PeerUnknownState
+     *
+     *@brief class default constructor
+     */
+    PeerUnknownState() = delete;
+
+    /**
+     *@method PeerUnknownState
+     *
+     *@brief class copy constructor
+     *
+     *@param PeerUnknownState (in)  reference to PeerUnknownState object to be copied
+     */
+    PeerUnknownState(const PeerUnknownState &) = delete;
+
+    /**
+     *@method PeerUnknownState
+     *
+     *@brief class constructor
+     *
+     *@param stateMachine (in)   reference to LinkProberStateMachineBase
+     *@param muxPortConfig (in)  reference to MuxPortConfig object
+     */
+    PeerUnknownState(
+        LinkProberStateMachineBase &stateMachine,
+        common::MuxPortConfig &muxPortConfig
+    );
+
+    /**
+     *@method ~PeerUnknownState
+     *
+     *@brief class destructor
+     */
+    virtual ~PeerUnknownState() = default;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerActiveEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerActiveEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerActiveEvent &event) override;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerUnknownEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerUnknownEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerUnknownEvent &event) override;
+
+    /**
+     *@method resetState
+     *
+     *@brief reset current state attributes
+     *
+     *@return none
+     */
+    virtual void resetState() override;
+
+    /**
+     *@method getStateLabel
+     *
+     *@brief getter for LinkeProberState label
+     *
+     *@return LinkProberState Unknown label
+     */
+    virtual LinkProberState::Label getStateLabel() override { return LinkProberState::Label::Unknown; };
+
+private:
+    uint8_t mPeerEventCount = 0;
+};
+
+} /* namespace link_prober */
+
+#endif /* LINK_PROBER_PEERUNKNOWNSTATE_H_ */

--- a/src/link_prober/subdir.mk
+++ b/src/link_prober/subdir.mk
@@ -1,6 +1,8 @@
 # Add inputs and outputs from these tool invocations to the build variables 
 CPP_SRCS += \
     ./src/link_prober/ActiveState.cpp \
+    ./src/link_prober/PeerActiveState.cpp \
+    ./src/link_prober/PeerUnknownState.cpp \
     ./src/link_prober/IcmpPayload.cpp \
     ./src/link_prober/LinkProber.cpp \
     ./src/link_prober/LinkProberState.cpp \
@@ -12,6 +14,8 @@ CPP_SRCS += \
 
 OBJS += \
     ./src/link_prober/ActiveState.o \
+    ./src/link_prober/PeerActiveState.o \
+    ./src/link_prober/PeerUnknownState.o \
     ./src/link_prober/IcmpPayload.o \
     ./src/link_prober/LinkProber.o \
     ./src/link_prober/LinkProberState.o \
@@ -23,6 +27,8 @@ OBJS += \
 
 CPP_DEPS += \
     ./src/link_prober/ActiveState.d \
+    ./src/link_prober/PeerActiveState.d \
+    ./src/link_prober/PeerUnknownState.d \
     ./src/link_prober/IcmpPayload.d \
     ./src/link_prober/LinkProber.d \
     ./src/link_prober/LinkProberState.d \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [x] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To support future support to report peer link prober state, add peer link prober event and state.

#### How did you do it?
Add new link prober peer events:
* `IcmpPeerActiveEvent`
* `IcmpPeerUnknownEvent`

Add the new link prober peer state:
* `PeerActiveState`
* `PeerUnknownState`

Future link prober could report the peer events to the link prober state machine via `LinkProberStateMachineBase::postLinkProberStateEvent`, which will call LinkProberStateMachineBase::processEvent` to handle the event, so add the following two new virtual overloads to handle peer events:
* `processEvent(IcmpPeerActiveEvent &)`
*`processEvent(IcmpPeerUnknownEvent &)`

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->