### PR TITLE
Add a command line option to store logs into a separate file

### DIFF
--- a/objects.mk
+++ b/objects.mk
@@ -8,6 +8,7 @@ LIBS := \
     -lboost_log \
     -lboost_log_setup \
     -lboost_program_options \
+    -lboost_filesystem \
     -lnl-3 \
     -lnl-route-3
 

--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -42,12 +42,12 @@ namespace {
 
     static auto DEFAULT_LOGGING_FILTER_LEVEL = boost::log::trivial::debug;
 
-    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level)
+    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level, bool extraLogFile)
     {
         std::string progName = execName.substr(execName.find_last_of('/') + 1);
         std::string logFile = "/var/log/mux/" + progName + ".log";
 
-        common::MuxLogger::getInstance()->initialize(progName, logFile, level);
+        common::MuxLogger::getInstance()->initialize(progName, logFile, level, extraLogFile);
     }
 
 } // end namespace
@@ -64,6 +64,7 @@ int main(int argc, const char* argv[])
     // Constants for command line argument strings:
     //
     boost::log::trivial::severity_level level;
+    bool extraLogFile = false;
 
     program_options::options_description description("linkmgrd options");
     description.add_options()
@@ -73,6 +74,9 @@ int main(int argc, const char* argv[])
          program_options::value<boost::log::trivial::severity_level>(&level)->value_name("<severity_level>")->
          default_value(DEFAULT_LOGGING_FILTER_LEVEL),
          "Logging verbosity level.")
+        ("extra_log_file,e",
+         program_options::bool_switch(&extraLogFile)->default_value(false),
+         "Store logs in an extra log file")
     ;
 
     //
@@ -101,7 +105,7 @@ int main(int argc, const char* argv[])
     }
 
     if (retValue == EXIT_SUCCESS) {
-        InitializeLogger(argv[0], level);
+        InitializeLogger(argv[0], level, extraLogFile);
         std::stringstream ss;
         ss << "level: " << level;
         MUXLOGINFO(ss.str());

--- a/src/common/MuxLogger.cpp
+++ b/src/common/MuxLogger.cpp
@@ -86,7 +86,8 @@ MuxLoggerPtr MuxLogger::getInstance()
 void MuxLogger::initialize(
     std::string &prog,
     std::string &path,
-    boost::log::trivial::severity_level level
+    boost::log::trivial::severity_level level,
+    bool extraLogFile
 )
 {
     namespace trivial = boost::log::trivial;
@@ -99,12 +100,13 @@ void MuxLogger::initialize(
     boost::log::settings settings;
     boost::log::init_from_settings(settings);
 
-//    boost::filesystem::remove(path);
-
-//    boost::log::add_file_log(
-//        keywords::file_name = path,
-//        keywords::format = "[%TimeStamp%] [%Severity%] %Message%"
-//    );
+    if (extraLogFile) {
+        boost::filesystem::remove(path);
+        boost::log::add_file_log(
+            keywords::file_name = path,
+            keywords::format = "[%TimeStamp%] [%Severity%] %Message%"
+        );
+    }
 
     boost::log::add_common_attributes();
     boost::log::core::get()->set_exception_handler(

--- a/src/common/MuxLogger.h
+++ b/src/common/MuxLogger.h
@@ -109,13 +109,14 @@ public:
     *
     *@brief initialize MUX logging class
     *
-    *@param prog (in)   program name to be used when logging
-    *@param path (in)   path on file system to MUX logging file
-    *@param level (in)  minimum logging severity level
+    *@param prog (in)           program name to be used when logging
+    *@param path (in)           path on file system to MUX logging file
+    *@param level (in)          minimum logging severity level
+    *@param extraLogFile (in)   save log in an extra log file
     *
     *@return none
     */
-    void initialize(std::string &prog, std::string &path, boost::log::trivial::severity_level level);
+    void initialize(std::string &prog, std::string &path, boost::log::trivial::severity_level level, bool extraLogFile);
 
     /**
     *@method setLevel

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -54,7 +54,8 @@ FakeMuxPort::FakeMuxPort(
 {
     std::string prog_name = "linkmgrd-test";
     std::string log_filename = "/tmp/" + prog_name + ".log";
-    common::MuxLogger::getInstance()->initialize(prog_name, log_filename, boost::log::trivial::debug);
+    bool extraLogFile = true;
+    common::MuxLogger::getInstance()->initialize(prog_name, log_filename, boost::log::trivial::debug, extraLogFile);
     common::MuxLogger::getInstance()->setLevel(boost::log::trivial::trace);
     mMuxPortConfig.setMode(common::MuxPortConfig::Mode::Auto);
     getActiveStandbyStateMachinePtr()->setInitializeProberFnPtr(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Support store logs into a separate log file.

#### How did you do it?
Add an option `-e` or `--extra_log_file`, if present, stores the logs from `linkmgrd` into `/var/log/mux/linkmgrd.log`.

#### How did you verify/test it?
Run `linkmgrd` with the option on/off

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->