### PR TITLE
Shutdown ICMP heartbeats when default route state is missing and ToR is in `auto` mode

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -384,7 +384,7 @@ void ActiveStandbyStateMachine::handleSwssBladeIpv4AddressUpdate(boost::asio::ip
                 &link_prober::LinkProber::shutdownTxProbes, mLinkProberPtr.get()
             );
             mRestartTxFnPtr = boost::bind(
-                &link_prober::LinkProber::restartTxProbes(), mLinkProberPtr.get()
+                &link_prober::LinkProber::restartTxProbes, mLinkProberPtr.get()
             );
             mComponentInitState.set(LinkProberComponent);
 
@@ -849,16 +849,17 @@ void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const std::s
 //
 void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
 {
-    if (mComponentInitState.all() && mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
-        if (mDefaultRouteState == "na") {
+    MUXLOGWARNING(boost::format("%s: default route state: %s") % mMuxPortConfig.getPortName() % mDefaultRouteState);
+
+    if (mComponentInitState.all()) {
+        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == "na") {
             mShutdownTxFnPtr();
-        }
-        
-        if (mDefaultRouteState == "ok")
-        {
+        } else {
+            // If mux mode is in manual/standby/active mode, we should restart link prober. 
+            // If default route state is "ok", we should retart link prober.
             mRestartTxFnPtr();
         }
-    } 
+    }
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -390,6 +390,15 @@ public:
     void handleDefaultRouteStateNotification(const std::string &routeState);
 
     /**
+     * @method shutdownOrRestartLinkProberOnDefaultRoute()
+     * 
+     * @brief  shutdown or restart link prober based on default route state
+     * 
+     * @return none
+     */
+    void shutdownOrRestartLinkProberOnDefaultRoute();
+
+    /**
      * @method handlePostPckLossRatioNotification
      * 
      * @brief handle get post pck loss ratio 
@@ -825,6 +834,8 @@ private:
     boost::function<void ()> mResumeTxFnPtr;
     boost::function<void ()> mSendPeerSwitchCommandFnPtr;
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
+    boost::function<void ()> mShutdownTxFnPtr;
+    boost::function<void ()> mRestartTxFnPtr;
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
@@ -834,6 +845,8 @@ private:
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;
 
     bool mContinuousLinkProberUnknownEvent = false;
+
+    std::string mDefaultRouteState = "na";
 
     std::bitset<ComponentCount> mComponentInitState = {0};
 };

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -889,13 +889,10 @@ private:
     boost::function<void ()> mResumeTxFnPtr;
     boost::function<void ()> mSendPeerSwitchCommandFnPtr;
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
-<<<<<<< HEAD
     boost::function<void ()> mShutdownTxFnPtr;
     boost::function<void ()> mRestartTxFnPtr;
-=======
     boost::function<void (uint32_t switchTime_msec)> mDecreaseIntervalFnPtr;
     boost::function<void ()> mRevertIntervalFnPtr;
->>>>>>> c43cf7a95acd61a2191cdb4909e5c3615071b3aa
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -820,6 +820,32 @@ private:
     */
     void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
 
+    /**
+     * @method setShutdownTxFnPtr
+     * 
+     * @brief set shutdownTxFnPtr. This method is used for testing
+     * 
+     * @param shutdownTxFnPtr (in) pointer to new ShutdownTxFnPtr
+     * 
+     * @return none
+     */
+    void setShutdownTxFnPtr(boost::function<void ()> shutdownTxFnPtr) {
+        mShutdownTxFnPtr = shutdownTxFnPtr;
+    }
+
+    /**
+     * @method setRestartTxFnPtr
+     * 
+     * @brief set restartTxFnPtr. This method is used for testing
+     * 
+     * @param restartTxFnPtr (in) pointer to new restartTxFnPtr
+     * 
+     * @return none
+     */
+    void setRestartTxFnPtr(boost::function<void ()> restartTxFnPtr) {
+        mRestartTxFnPtr = restartTxFnPtr;
+    }
+
 private:
     link_state::LinkState::Label mPeerLinkState = link_state::LinkState::Label::Down;
 

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -213,6 +213,17 @@ void LinkManagerStateMachineBase::handleDefaultRouteStateNotification(const std:
 }
 
 //
+//
+// ---> shutdownOrRestartLinkProberOnDefaultRoute();
+//
+// shutdown or restart link prober based on default route state
+//
+void LinkManagerStateMachineBase::shutdownOrRestartLinkProberOnDefaultRoute()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
 // ---> handlePostPckLossRatioNotification(const uint64_t unknownEventCount, const uint64_t expectedPacketCount);
 //
 // handle post pck loss ratio

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -341,6 +341,15 @@ public:
     virtual void handleDefaultRouteStateNotification(const std::string& routeState);
 
     /**
+     * @method shutdownOrRestartLinkProberOnDefaultRoute()
+     * 
+     * @brief  shutdown or restart link prober based on default route state
+     * 
+     * @return none
+     */
+    virtual void shutdownOrRestartLinkProberOnDefaultRoute();
+
+    /**
      * @method handlePostPckLossRatioNotification
      *
      * @brief handle get post pck loss ratio

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -271,7 +271,7 @@ void LinkProber::sendHeartbeat()
     MUXLOGTRACE(mMuxPortConfig.getPortName());
 
     // check if suspend timer is running
-    if (!mSuspendTx) {
+    if ((!mSuspendTx) && (!mShutdownTx)) {
         updateIcmpSequenceNo();
         boost::system::error_code errorCode;
         mStream.write_some(boost::asio::buffer(mTxBuffer.data(), mTxPacketSize), errorCode);
@@ -746,6 +746,20 @@ void LinkProber::resetIcmpPacketCounts()
         mIcmpUnknownEventCount,
         mIcmpPacketCount
     )));
+}
+
+void LinkProber::shutdownTxProbes()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mShutdownTx = true;
+}
+
+void LinkProber::restartTxProbes()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mShutdownTx = false;
 }
 
 } /* namespace link_prober */

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -169,6 +169,24 @@ public:
     */
     void resetIcmpPacketCounts();
 
+    /**
+     * @method shutdownTxProbes
+     * 
+     * @brief stop sending ICMP ECHOREQUEST packets indefinitely.
+     * 
+     * @return none
+     */
+    void shutdownTxProbes();
+
+    /**
+     * @method restartTxProbes
+     * 
+     * @brief restart sending ICMP ECHOREQUEST packets
+     * 
+     * @return none
+     */
+    void restartTxProbes();
+
 private:
     /**
     *@method handleUpdateEthernetFrame
@@ -444,6 +462,7 @@ private:
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
 
     bool mSuspendTx = false;
+    bool mShutdownTx = false;
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -137,4 +137,18 @@ void FakeLinkProber::resetIcmpPacketCounts()
         mIcmpPacketCount
     )));
 }
+
+void FakeLinkProber::shutdownTxProbes()
+{
+    MUXLOGINFO("");
+
+    mShutdownTxProbeCallCount++;
+}
+
+void FakeLinkProber::restartTxProbes()
+{
+    MUXLOGINFO("");
+    
+    mRestartTxProbeCallCount++;
+}
 } /* namespace test */

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -47,6 +47,8 @@ public:
     void resumeTxProbes();
     void sendPeerSwitchCommand();
     void resetIcmpPacketCounts();
+    void shutdownTxProbes();
+    void restartTxProbes();
 
 public:
     uint32_t mInitializeCallCount = 0;
@@ -56,6 +58,8 @@ public:
     uint32_t mSuspendTxProbeCallCount = 0;
     uint32_t mResumeTxProbeCallCount = 0;
     uint32_t mSendPeerSwitchCommand = 0;
+    uint32_t mShutdownTxProbeCallCount = 0;
+    uint32_t mRestartTxProbeCallCount = 0;
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -79,6 +79,12 @@ FakeMuxPort::FakeMuxPort(
     getActiveStandbyStateMachinePtr()->setSendPeerSwitchCommandFnPtr(
         boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
+    getActiveStandbyStateMachinePtr()->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    getActiveStandbyStateMachinePtr()->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
 }
 
 void FakeMuxPort::activateStateMachine()

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1059,29 +1059,18 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
 {
     setMuxActive();
 
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 0);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
     postDefaultRouteEvent("na", 3);
-    
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 1);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 
 {
     setMuxStandby();
 
-    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 0);
-    postDefaultRouteEvent("ok", 2);
-
-    VALIDATE_STATE(Standby, Wait, Up);
-    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 1);
-
-    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
-    VALIDATE_STATE(Standby, Wait, Up);
-
-    handleMuxState("standby", 3);
-    VALIDATE_STATE(Standby, Standby, Up);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,0);
+    postDefaultRouteEvent("ok", 3);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -224,6 +224,12 @@ void MuxManagerTest::createPort(std::string port)
     linkManagerStateMachine->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );
+    linkManagerStateMachine->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachine->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
 
     linkManagerStateMachine->mComponentInitState.set(0);
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address the expected behavior on default route states: 
1.	If in “manual” mode, default route state change should NOT trigger mux state change. 
2.	If in “auto” mode, default route state change to “na”, should trigger switchover to “standby”.
3.	Avoid switchovers to “active” if default route state remains “na”. 

Sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To handle default route state change. Make a healthy peer always takes over when self's missing default route state. 

#### How did you do it?
Shutdown heartbeats when default route state is missing and the mode is `auto`. 

Also make sure to restart the heartbeats when ToR enters manual mode or default route state is `ok`. 
#### How did you verify/test it?
Tested on dual testbeds. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->