### PR TITLE
Decrease link probing interval after switchover to better determine the overhead of a toggle #43

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -46,7 +46,7 @@ constexpr auto DEFAULT_TIMEOUT_MSEC = 1000;
 std::vector<std::string> DbInterface::mMuxState = {"active", "standby", "unknown", "Error"};
 std::vector<std::string> DbInterface::mMuxLinkmgrState = {"uninitialized", "unhealthy", "healthy"};
 std::vector<std::string> DbInterface::mMuxMetrics = {"start", "end"};
-std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end"};
+std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end", "link_prober_wait_start", "link_prober_active_start", "link_prober_standby_start"};
 
 //
 // ---> DbInterface(mux::MuxManager *muxManager);
@@ -168,13 +168,13 @@ void DbInterface::postMetricsEvent(
 //        link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
 //    );
 //
-// post link probe pck loss event to state db 
+// post link probe event to state db 
 void DbInterface::postLinkProberMetricsEvent(
         const std::string &portName, 
         link_manager::LinkManagerStateMachine::LinkProberMetrics metrics
 )
 {
-    MUXLOGWARNING(boost::format("%s: posting link prober pck loss event %s") %
+    MUXLOGWARNING(boost::format("%s: posting link prober event %s") %
         portName %
         mLinkProbeMetrics[static_cast<int> (metrics)]
     );
@@ -393,7 +393,7 @@ void DbInterface::handlePostLinkProberMetrics(
     boost::posix_time::ptime time
 )
 {
-    MUXLOGWARNING(boost::format("%s: posting link prober pck loss event %s") %
+    MUXLOGWARNING(boost::format("%s: posting link prober event %s") %
         portName %
         mLinkProbeMetrics[static_cast<int> (metrics)]
     );

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -176,10 +176,10 @@ public:
     /**
      * @method postLinkProberMetricsEvent
      * 
-     * @brief post link prober pck loss event
+     * @brief post link prober event
      * 
      * @param portName (in) port name 
-     * @param metrics (in) pck loss event name 
+     * @param metrics (in) link prober event name 
      * 
      * @return none
      * 
@@ -316,7 +316,7 @@ private:
     /**
      * @method handlePostLinkProberMetrics
      * 
-     * @brief post link prober pck loss event to state db 
+     * @brief post link prober event to state db 
      * 
      * @param portName (in) port name
      * @param metrics (in) metrics data

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -266,6 +266,15 @@ public:
     *@return IPv4 address
     */
     inline boost::asio::ip::address getLoopbackIpv4Address() {return mLoopbackIpv4Address;};
+    
+    /**
+    *@method getDecreasedTimeoutIpv4_msec
+    *
+    *@brief getter for decreased IPv4 LinkProber timeout in msec
+    *
+    *@return timeout in msec
+    */
+    inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mDecreasedTimeoutIpv4_msec;};
 
 private:
     uint8_t mNumberOfThreads = 5;
@@ -276,6 +285,8 @@ private:
     uint32_t mSuspendTimeout_msec = 500;
     uint32_t mMuxStateChangeRetryCount = 1;
     uint32_t mLinkStateChangeRetryCount = 1;
+
+    uint32_t mDecreasedTimeoutIpv4_msec = 10;
 
     std::array<uint8_t, ETHER_ADDR_LEN> mTorMacAddress;
     boost::asio::ip::address mLoopbackIpv4Address = boost::asio::ip::make_address("10.212.64.0");

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -260,15 +260,6 @@ public:
     */
     inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
 
-    /**
-    *@method getDecreasedTimeoutIpv4_msec
-    *
-    *@brief getter for decreased IPv4 LinkProber timeout in msec
-    *
-    *@return timeout in msec
-    */
-    inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
-
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -260,6 +260,15 @@ public:
     */
     inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
 
+    /**
+    *@method getDecreasedTimeoutIpv4_msec
+    *
+    *@brief getter for decreased IPv4 LinkProber timeout in msec
+    *
+    *@return timeout in msec
+    */
+    inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -251,6 +251,15 @@ public:
     */
     inline Mode getMode() const {return mMode;};
 
+    /**
+    *@method getDecreasedTimeoutIpv4_msec
+    *
+    *@brief getter for decreased IPv4 LinkProber timeout in msec
+    *
+    *@return timeout in msec
+    */
+    inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -301,6 +301,11 @@ void LinkManagerStateMachine::enterLinkProberState(CompositeState &nextState, li
 {
     mLinkProberStateMachine.enterState(label);
     ps(nextState) = label;
+
+    // link prober entering wait indicating switchover is initiated, but a switchover can be skipped if mode == manual.
+    if(label == link_prober::LinkProberState::Label::Wait) {
+        mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberWaitStart);
+    }
 }
 
 //
@@ -358,6 +363,7 @@ void LinkManagerStateMachine::switchMuxState(
         mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
         mMuxPortPtr->postMetricsEvent(Metrics::SwitchingStart, label);
         mMuxPortPtr->setMuxState(label);
+        mDecreaseIntervalFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec()); 
         mDeadlineTimer.cancel();
         startMuxWaitTimer();
     } else {
@@ -405,6 +411,12 @@ void LinkManagerStateMachine::handleSwssBladeIpv4AddressUpdate(boost::asio::ip::
             );
             mResetIcmpPacketCountsFnPtr = boost::bind(
                 &link_prober::LinkProber::resetIcmpPacketCounts, mLinkProberPtr.get()
+            );
+            mDecreaseIntervalFnPtr = boost::bind(
+                &link_prober::LinkProber::decreaseProbeIntervalAfterSwitch, mLinkProberPtr.get(), boost::placeholders::_1
+            );
+            mRevertIntervalFnPtr = boost::bind(
+                &link_prober::LinkProber::revertProbeIntervalAfterSwitchComplete, mLinkProberPtr.get()
             );
             mComponentInitState.set(LinkProberComponent);
 
@@ -471,13 +483,17 @@ void LinkManagerStateMachine::handleStateChange(LinkProberEvent &event, link_pro
             mLinkProberStateName[state]
         );
 
-        // update state db link prober metrics to collect pck loss data
+        // update state db link prober metrics to collect link prober state change data
         if (mContinuousLinkProberUnknownEvent == true && state != link_prober::LinkProberState::Unknown) {
             mContinuousLinkProberUnknownEvent = false;
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberUnknownEnd);
         } else if (state == link_prober::LinkProberState::Label::Unknown) {
             mContinuousLinkProberUnknownEvent = true;
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberUnknownStart);
+        } else if (state == link_prober::LinkProberState::Label::Active) {
+            mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberActiveStart);
+        } else if (state == link_prober::LinkProberState::Label::Standby) {
+            mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberStandbyStart);
         }
 
         CompositeState nextState = mCompositeState;
@@ -860,7 +876,7 @@ void LinkManagerStateMachine::handleDefaultRouteStateNotification(const std::str
     if (mComponentInitState.test(MuxStateComponent)) {
         if (ms(mCompositeState) != mux_state::MuxState::Label::Standby && routeState == "na") {
             mSendPeerSwitchCommandFnPtr();
-            // In case Mux is in wait state, switchMuxSate(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established.
+            // In case Mux is in wait state, switchMuxState(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established.
             mMuxPortPtr->setMuxState(mux_state::MuxState::Label::Standby);
         } else {
             enterMuxWaitState(mCompositeState);
@@ -909,6 +925,7 @@ void LinkManagerStateMachine::updateMuxLinkmgrState()
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Standby &&
          ms(mCompositeState) == mux_state::MuxState::Label::Standby))) {
         label = Label::Healthy;
+        mRevertIntervalFnPtr();
     }
 
     setLabel(label);
@@ -988,7 +1005,7 @@ void LinkManagerStateMachine::handleMuxWaitTimeout(boost::system::error_code err
             // on the 3rd timeout, send switch active command to peer
             if (mMuxWaitTimeoutCount == mMuxPortConfig.getNegativeStateChangeRetryCount()) { 
                 mSendPeerSwitchCommandFnPtr();
-                // Mux is in wait state, switchMuxSate(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established. 
+                // Mux is in wait state, switchMuxState(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established. 
                 mMuxPortPtr->setMuxState(mux_state::MuxState::Label::Standby); 
             }
         } else {

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -304,7 +304,7 @@ void LinkManagerStateMachine::enterLinkProberState(CompositeState &nextState, li
 
     // link prober entering wait indicating switchover is initiated, but a switchover can be skipped if mode == manual.
     if(label == link_prober::LinkProberState::Label::Wait) {
-        mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberWaitStart);
+        mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberWaitStart);
     }
 }
 

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -124,6 +124,9 @@ public:
     enum class LinkProberMetrics {
         LinkProberUnknownStart, 
         LinkProberUnknownEnd,
+        LinkProberWaitStart,
+        LinkProberActiveStart,
+        LinkProberStandbyStart,
 
         Count
     };
@@ -927,6 +930,32 @@ private:
     */
     void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
 
+    /**
+     * @method setDecreaseIntervalFnPtr
+     * 
+     * @brief set new DecreaseIntervalFnPtr for the state machine. This method is used for testing
+     * 
+     * @param DecreaseIntervalFnPtr (in) pointer to new DecreaseIntervalFnPtr
+     * 
+     * @return none
+     */
+    void setDecreaseIntervalFnPtr(boost::function<void (uint32_t switchTime_msec)> DecreaseIntervalFnPtr) {
+        mDecreaseIntervalFnPtr = DecreaseIntervalFnPtr;
+    };
+
+    /**
+     * @method setRevertIntervalFnPtr
+     * 
+     * @brief set new RevertIntervalFnPtr for the state machine. This method is used for testing
+     * 
+     * @param  RevertIntervalFnPtr (in) pointer to new RevertIntervalFnPtr
+     * 
+     * @return none
+     */
+    void setRevertIntervalFnPtr(boost::function<void ()>  RevertIntervalFnPtr) {
+        mRevertIntervalFnPtr = RevertIntervalFnPtr;
+    };
+
 private:
     static TransitionFunction mStateTransitionHandler[link_prober::LinkProberState::Label::Count]
                                                      [mux_state::MuxState::Label::Count]
@@ -968,6 +997,8 @@ private:
     boost::function<void ()> mResumeTxFnPtr;
     boost::function<void ()> mSendPeerSwitchCommandFnPtr;
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
+    boost::function<void (uint32_t switchTime_msec)> mDecreaseIntervalFnPtr;
+    boost::function<void ()> mRevertIntervalFnPtr;
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
@@ -976,7 +1007,7 @@ private:
     bool mPendingMuxModeChange = false;
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;
 
-    bool mContinuousLinkProberUnknownEvent = false;
+    bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
     std::bitset<ComponentCount> mComponentInitState = {0};
     Label mLabel = Label::Uninitialized;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -74,6 +74,7 @@ LinkProber::LinkProber(
     mStrand(mIoService),
     mDeadlineTimer(mIoService),
     mSuspendTimer(mIoService),
+    mSwitchoverTimer(mIoService),
     mStream(mIoService)
 {
     try {
@@ -532,7 +533,7 @@ void LinkProber::startTimer()
 {
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
     // time out these heartbeats
-    mDeadlineTimer.expires_from_now(boost::posix_time::milliseconds(mMuxPortConfig.getTimeoutIpv4_msec()));
+    mDeadlineTimer.expires_from_now(boost::posix_time::milliseconds(getProbingInterval()));
     mDeadlineTimer.async_wait(mStrand.wrap(boost::bind(
         &LinkProber::handleTimeout,
         this,
@@ -746,6 +747,63 @@ void LinkProber::resetIcmpPacketCounts()
         mIcmpUnknownEventCount,
         mIcmpPacketCount
     )));
+}
+
+//
+// ---> decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
+//
+//  adjust link prober interval to 10 ms after switchover to better measure the switchover overhead.
+//
+void LinkProber::decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec)
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mSwitchoverTimer.expires_from_now(boost::posix_time::milliseconds(switchTime_msec));
+    mSwitchoverTimer.async_wait(mStrand.wrap(boost::bind(
+        &LinkProber::handleSwitchoverTimeout,
+        this,
+        boost::asio::placeholders::error
+    )));
+
+    mDecreaseProbingInterval = true;
+}
+
+// ---> revertProbeIntervalAfterSwitchComplete();
+//
+// revert probe interval change after switchover is completed
+// 
+void LinkProber::revertProbeIntervalAfterSwitchComplete()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mSwitchoverTimer.cancel();
+    mDecreaseProbingInterval = false;
+}
+
+//
+// ---> handleSwitchoverTimeout(boost::system::error_code errorCode)
+//
+// handle switchover time out 
+// 
+void LinkProber::handleSwitchoverTimeout(boost::system::error_code errorCode)
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mDecreaseProbingInterval = false;
+    if (errorCode == boost::system::errc::success) {
+        MUXLOGWARNING(boost::format("%s: link prober timeout on waiting for expected ICMP event after switchover is triggered ") % mMuxPortConfig.getPortName());
+    }
+}
+
+//
+// ---> getProbingInterval
+// 
+// get link prober interval
+//
+inline uint32_t LinkProber::getProbingInterval()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    return mDecreaseProbingInterval? mMuxPortConfig.getDecreasedTimeoutIpv4_msec():mMuxPortConfig.getTimeoutIpv4_msec();
 }
 
 } /* namespace link_prober */

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -169,6 +169,27 @@ public:
     */
     void resetIcmpPacketCounts();
 
+    /**
+     * @method decreaseProbeIntervalAfterSwitch
+     *  
+     * @brief adjust link prober interval to 10 ms after switchover to better measure the switchover overhead.
+     * 
+     * @param switchTime_msec (in) switchover is expected to complete  within this time window
+     * @param expectingLinkProberEvent (in) depends on which state LinkManager is switching to, link prober expects self or peer events
+     * 
+     * @return none
+     */
+    void decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
+
+    /**
+     * @method revertProbeIntervalAfterSwitchComplete 
+     * 
+     * @brief revert probe interval change after switchover is completed
+     * 
+     * @return none
+     */
+    void revertProbeIntervalAfterSwitchComplete();
+
 private:
     /**
     *@method handleUpdateEthernetFrame
@@ -408,6 +429,26 @@ private:
     *@return the appended TLV size
     */
     size_t appendTlvDummy(size_t paddingSize, int seqNo);
+    
+    /**
+     * @method getProbingInterval
+     * 
+     * @brief get link prober interval
+     * 
+     * @return link prober interval
+     */
+    inline uint32_t getProbingInterval(); 
+
+    /**
+     * @method handleSwitchoverTimeout
+     * 
+     * @brief handle switchover time out 
+     * 
+     * @param errorCode (in) socket error code 
+     * 
+     * @return none
+     */
+    void handleSwitchoverTimeout(boost::system::error_code errorCode);
 
     friend class test::LinkProberTest;
 
@@ -432,6 +473,7 @@ private:
     boost::asio::io_service::strand mStrand;
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mSuspendTimer;
+    boost::asio::deadline_timer mSwitchoverTimer;
     boost::asio::posix::stream_descriptor mStream;
 
     std::shared_ptr<SockFilter> mSockFilterPtr;
@@ -444,6 +486,7 @@ private:
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
 
     bool mSuspendTx = false;
+    bool mDecreaseProbingInterval = false;
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -137,4 +137,19 @@ void FakeLinkProber::resetIcmpPacketCounts()
         mIcmpPacketCount
     )));
 }
+
+void FakeLinkProber::decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec)
+{
+    MUXLOGINFO("");
+
+    mDecreaseIntervalCallCount++;
+}
+
+void FakeLinkProber::revertProbeIntervalAfterSwitchComplete()
+{
+    MUXLOGINFO("");
+
+    mRevertIntervalCallCount++;
+}
+
 } /* namespace test */

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -47,6 +47,9 @@ public:
     void resumeTxProbes();
     void sendPeerSwitchCommand();
     void resetIcmpPacketCounts();
+    void decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
+    void revertProbeIntervalAfterSwitchComplete();
+
 
 public:
     uint32_t mInitializeCallCount = 0;
@@ -59,6 +62,9 @@ public:
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;
+
+    uint32_t mDecreaseIntervalCallCount = 0;
+    uint32_t mRevertIntervalCallCount = 0;
 
 private:
     link_prober::LinkProberStateMachine *mLinkProberStateMachine;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -75,10 +75,10 @@ FakeMuxPort::FakeMuxPort(
     getLinkManagerStateMachine()->setSendPeerSwitchCommandFnPtr(
         boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
-    getActiveStandbyStateMachinePtr()->setDecreaseIntervalFnPtr(
+    getLinkManagerStateMachine()->setDecreaseIntervalFnPtr(
         boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
     );
-    getActiveStandbyStateMachinePtr()->setRevertIntervalFnPtr(
+    getLinkManagerStateMachine()->setRevertIntervalFnPtr(
         boost::bind(&FakeLinkProber::revertProbeIntervalAfterSwitchComplete, mFakeLinkProber.get())
     );
 }

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -75,6 +75,12 @@ FakeMuxPort::FakeMuxPort(
     getLinkManagerStateMachine()->setSendPeerSwitchCommandFnPtr(
         boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
+    getActiveStandbyStateMachinePtr()->setDecreaseIntervalFnPtr(
+        boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
+    );
+    getActiveStandbyStateMachinePtr()->setRevertIntervalFnPtr(
+        boost::bind(&FakeLinkProber::revertProbeIntervalAfterSwitchComplete, mFakeLinkProber.get())
+    );
 }
 
 void FakeMuxPort::activateStateMachine()

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1114,13 +1114,13 @@ TEST_F(LinkManagerStateMachineTest, PostPckLossMetricsEvent)
 {
     setMuxStandby();
     
-    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 0);
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 1);  // post link_prober_standby_start
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
 
-    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 3); // post link_prober_unknown_start, link_prober_wait_start
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     
-    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 4); // post link_prober_active_start
 }
 
 TEST_F(LinkManagerStateMachineTest, PostPckLossUpdateAndResetEvent)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -209,6 +209,12 @@ void MuxManagerTest::createPort(std::string port)
     linkManagerStateMachine->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );
+    linkManagerStateMachine->setDecreaseIntervalFnPtr(
+        boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
+    );
+    linkManagerStateMachine->setRevertIntervalFnPtr(
+        boost::bind(&FakeLinkProber::revertProbeIntervalAfterSwitchComplete, mFakeLinkProber.get())
+    );
 
     linkManagerStateMachine->mComponentInitState.set(0);
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Original commit & PR in master branch: 

c43cf7a Jing Zhang      Tue Mar 22 16:22:00 2022 -0700  Decrease link probing interval after switchover to better determine the overhead of a toggle (#43)

Summary:
Fixes # (issue)

This PR is to get more accurate timestamp of when toggle completes on mux.  

The method is to decrease link probing interval to 10ms after a switchover is triggered, and write the timestamp of link prober state change to state db ```LINK_PROBE_STATS table```.

When switchover is over, revert the probing interval change. If switchover does not complete within 400ms, revert the change as well. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To better determine the overhead of a toggle. 

#### How did you do it?
Decrease link probing interval after switchover is triggered. 

#### How did you verify/test it?
Tested cases below on dual testbed: 
1. switchover succeeds, icmp_respnder is on. 
2. switchover completes but icmp_responder is off. 

In both cases, link prober events are posted to state db as expected. Link probing interval is decreased and reverted as expected. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->