### PR TITLE
Update link prober metrics posting logics

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -461,12 +461,18 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
         if (mContinuousLinkProberUnknownEvent == true && state != link_prober::LinkProberState::Unknown) {
             mContinuousLinkProberUnknownEvent = false;
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberUnknownEnd);
-        } else if (state == link_prober::LinkProberState::Label::Unknown) {
+        } 
+        
+        if (mContinuousLinkProberUnknownEvent == false && state == link_prober::LinkProberState::Label::Unknown) {
             mContinuousLinkProberUnknownEvent = true;
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberUnknownStart);
-        } else if (state == link_prober::LinkProberState::Label::Active) {
+        } 
+        
+        if (state == link_prober::LinkProberState::Label::Active) {
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberActiveStart);
-        } else if (state == link_prober::LinkProberState::Label::Standby) {
+        }
+         
+        if (state == link_prober::LinkProberState::Label::Standby) {
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberStandbyStart);
         }
 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1120,7 +1120,7 @@ TEST_F(LinkManagerStateMachineTest, PostPckLossMetricsEvent)
     EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 3); // post link_prober_unknown_start, link_prober_wait_start
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     
-    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 4); // post link_prober_active_start
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 5); // post link_prober_unknown_start, post link_prober_active_start
 }
 
 TEST_F(LinkManagerStateMachineTest, PostPckLossUpdateAndResetEvent)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to post not only `link_prober_unknown_end` but also `link_prober_[active|standby]_start` metrics event to `LINK_PROBE_STATS|PORTNAME` table. Current behavior is to only post the former. 

sign-off: Jing Zhang jingzhang@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->