### PR TITLE
Disable the feature that decreases link probe interval for measuring switch overhead #49

### DIFF
--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -260,6 +260,15 @@ public:
     */
     inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mMuxConfig.getDecreasedTimeoutIpv4_msec();};
 
+    /**
+     * @method ifEnableSwitchoverMeasurement
+     * 
+     * @brief check if the feature that decreases link prober interval to measure switch overhead is enabled or not 
+     * 
+     * @return if switch overhead measurement feature is enabled
+     */
+    inline bool ifEnableSwitchoverMeasurement() {return mEnableSwitchoverMeasurement;};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;
@@ -267,6 +276,9 @@ private:
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;
+    PortCableType mPortCableType;
+
+    bool mEnableSwitchoverMeasurement = false;
 };
 
 } /* namespace common */

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -276,7 +276,6 @@ private:
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;
-    PortCableType mPortCableType;
 
     bool mEnableSwitchoverMeasurement = false;
 };

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -363,7 +363,9 @@ void LinkManagerStateMachine::switchMuxState(
         mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
         mMuxPortPtr->postMetricsEvent(Metrics::SwitchingStart, label);
         mMuxPortPtr->setMuxState(label);
-        mDecreaseIntervalFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec()); 
+        if(mMuxPortConfig.ifEnableSwitchoverMeasurement()) {
+            mDecreaseIntervalFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec()); 
+        }
         mDeadlineTimer.cancel();
         startMuxWaitTimer();
     } else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Can't cleanly cherry pick the commit from master branch: 
34a68d1 disable switchover measuring based on link prober (#49)

Summary:
Fixes # (issue)

Disable part of the feature introduced in #43. 

The link probing interval will NOT be decreased by default. Link prober state change events will still be posted in `LINK_PROBE_STATS|PORTNAME` in state db. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
We need to reconsider the design of this feature. 

To be more specific, this is a special case of decreasing probing interval, it's for measurement purposes only. We still want to trigger the toggle in 300ms when pack loss happens. The negative count should be 30 instead of 3 when interval is decreased to 10ms. 


#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->