### PR TITLE
Keep incrementing sequence number when link prober is suspended and shutdown 

### DIFF
--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -299,9 +299,10 @@ void LinkProber::sendHeartbeat()
 {
     MUXLOGTRACE(mMuxPortConfig.getPortName());
 
+    updateIcmpSequenceNo();
+    
     // check if suspend timer is running
     if ((!mSuspendTx) && (!mShutdownTx)) {
-        updateIcmpSequenceNo();
         boost::system::error_code errorCode;
         mStream.write_some(boost::asio::buffer(mTxBuffer.data(), mTxPacketSize), errorCode);
 

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -160,6 +160,17 @@ TEST_F(LinkProberTest, UpdateSequenceNo)
 
     EXPECT_TRUE(getRxSelfSeqNo() + 1 == ntohs(icmpHeader->un.echo.sequence));
     EXPECT_TRUE(getRxPeerSeqNo() + 1 == ntohs(icmpHeader->un.echo.sequence));
+
+    // sequence number should still be updated when heartbeat is suspended
+    EXPECT_EQ(getRxSelfSeqNo(), 0);
+    EXPECT_EQ(getRxPeerSeqNo(), 0);
+
+    handleSuspendTxProbes();
+    EXPECT_TRUE(getSuspendTx());
+    
+    handleSendHeartbeat();
+    EXPECT_EQ(getRxSelfSeqNo(), 1);
+    EXPECT_EQ(getRxPeerSeqNo(), 1);
 }
 
 TEST_F(LinkProberTest, GenerateGuid)

--- a/test/LinkProberTest.h
+++ b/test/LinkProberTest.h
@@ -42,6 +42,8 @@ public:
     void initializeSendBuffer() {mLinkProber.initializeSendBuffer();};
     void handleUpdateEthernetFrame() {mLinkProber.handleUpdateEthernetFrame();};
     void handleUpdateSequenceNumber() {mLinkProber.updateIcmpSequenceNo();};
+    void handleSuspendTxProbes() {mLinkProber.suspendTxProbes(300);};
+    void handleSendHeartbeat() {mLinkProber.sendHeartbeat();};
     void resetTxBufferTlv() {mLinkProber.resetTxBufferTlv();};
     size_t getTxPacketSize() {return mLinkProber.mTxPacketSize;};
     size_t appendTlvCommand(link_prober::Command commandType);
@@ -54,6 +56,7 @@ public:
 
     uint16_t getRxSelfSeqNo() {return mLinkProber.mRxSelfSeqNo;};
     uint16_t getRxPeerSeqNo() {return mLinkProber.mRxPeerSeqNo;};
+    bool getSuspendTx() {return mLinkProber.mSuspendTx;};
 
     boost::asio::io_service mIoService;
     common::MuxConfig mMuxConfig;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is fix the issue when both sides' link prober is suspended, LinkManager still appears to be healthy. 

When HB suspends, TX sequence number is not updated either, hence link prober won't post an `unknown` event. 

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Make sure link prober is reporting `unknown` event when it's suspended or shutdown on both sides. 

#### How did you do it?
Increment sequence number even when HB is not sent. 

#### How did you verify/test it?
Tested on dualToR testbed. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->