### PR TITLE
Reset link prober state when default route is back 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -861,6 +861,9 @@ void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const std::s
 {
     MUXLOGWARNING(boost::format("%s: state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
+    if (mDefaultRouteState == "na" && routeState == "ok") {
+        initLinkProberState(mCompositeState);
+    }
     mDefaultRouteState = routeState;
     shutdownOrRestartLinkProberOnDefaultRoute();
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address the edge case that when both sides are missing default route, and standby side gets default route back. Expected behavior is standby side will switch to active. But if standby side is `wait` state when link prober is restarted, the switchover won't happen. 

sign-off: Jing Zhang [zhangjing@microsoft.com](mailto:zhangjing@microsoft.com)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
When both sides are missing default route AND standby side gets default route back, we want to ensure the standby side will take over and switch to active. 

#### How did you do it?
Re-initialize link prober state when default route goes from `na` to `ok`. 

#### How did you verify/test it?
Tested below scenarios: 
1. Active side missing default route. 
2. Both sides missing default route one after another.
3. Both sides missing default route, standby side get it back. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->