### PR TITLE
Lower `unsolicited MUX state change notification` log level to `WARNING`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -645,7 +645,7 @@ void ActiveStandbyStateMachine::handleProbeMuxStateNotification(mux_state::MuxSt
 
     if (mComponentInitState.all()) {
         if (mMuxStateMachine.getWaitStateCause() != mux_state::WaitState::WaitStateCause::DriverUpdate) {
-            MUXLOGERROR(boost::format("%s: Received unsolicited MUX state probe notification!") %
+            MUXLOGWARNING(boost::format("%s: Received unsolicited MUX state probe notification!") %
                 mMuxPortConfig.getPortName()
             );
         }
@@ -687,7 +687,7 @@ void ActiveStandbyStateMachine::handleMuxStateNotification(mux_state::MuxState::
     if (mComponentInitState.all()) {
         if (mMuxStateMachine.getWaitStateCause() != mux_state::WaitState::WaitStateCause::SwssUpdate ||
             ms(mCompositeState) != mux_state::MuxState::Wait) {
-            MUXLOGERROR(boost::format("%s: Received unsolicited MUX state change notification!") %
+            MUXLOGWARNING(boost::format("%s: Received unsolicited MUX state change notification!") %
                 mMuxPortConfig.getPortName()
             );
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Stemming from sonic-mgmt issue: https://github.com/Azure/sonic-mgmt/issues/5410

This is PR to lower log level of message `unsolicited MUX state change notification`.

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->