### PR TITLE
Initializing default route as 'ok' in LinkManagerStateMachine

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -903,7 +903,7 @@ private:
 
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
-    std::string mDefaultRouteState = "na";
+    std::string mDefaultRouteState = "ok";
 
     std::bitset<ComponentCount> mComponentInitState = {0};
 };


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

`mDefaultRouteState` is a value cached in LinkManagerStateMachine. Initializing it as `na` might shutdown `LinkProber` unexpectedly at the initialing stages, as the order of processing db entries notification is not fixed.  

signoff: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Avoiding oscillation in initialization. 

#### How did you do it?

#### How did you verify/test it?
Run dualtor_io tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->