### PR TITLE
Shutdown ICMP heartbeats when default route state is missing and ToR is in auto mode #44

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -414,6 +414,12 @@ void LinkManagerStateMachine::handleSwssBladeIpv4AddressUpdate(boost::asio::ip::
             mResetIcmpPacketCountsFnPtr = boost::bind(
                 &link_prober::LinkProber::resetIcmpPacketCounts, mLinkProberPtr.get()
             );
+            mShutdownTxFnPtr = boost::bind(
+                &link_prober::LinkProber::shutdownTxProbes, mLinkProberPtr.get()
+            );
+            mRestartTxFnPtr = boost::bind(
+                &link_prober::LinkProber::restartTxProbes, mLinkProberPtr.get()
+            );
             mDecreaseIntervalFnPtr = boost::bind(
                 &link_prober::LinkProber::decreaseProbeIntervalAfterSwitch, mLinkProberPtr.get(), boost::placeholders::_1
             );
@@ -810,7 +816,7 @@ void LinkManagerStateMachine::handleMuxConfigNotification(const common::MuxPortC
     }
 
     mMuxPortConfig.setMode(mode);
-
+    shutdownOrRestartLinkProberOnDefaultRoute();
 }
 
 //
@@ -881,15 +887,29 @@ void LinkManagerStateMachine::handleDefaultRouteStateNotification(const std::str
 {
     MUXLOGWARNING(boost::format("%s: state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
-    if (mComponentInitState.test(MuxStateComponent)) {
-        if (ms(mCompositeState) != mux_state::MuxState::Label::Standby && routeState == "na") {
-            mSendPeerSwitchCommandFnPtr();
-            // In case Mux is in wait state, switchMuxState(standby) will be skipped. Setting mux state in app db to be standby so tunnel can be established.
-            mMuxPortPtr->setMuxState(mux_state::MuxState::Label::Standby);
+    mDefaultRouteState = routeState;
+    shutdownOrRestartLinkProberOnDefaultRoute();
+}
+
+//
+//
+// ---> shutdownOrRestartLinkProberOnDefaultRoute();
+//
+// shutdown or restart link prober based on default route state
+//
+void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
+{
+    MUXLOGWARNING(boost::format("%s: default route state: %s") % mMuxPortConfig.getPortName() % mDefaultRouteState);
+
+    if (mComponentInitState.all()) {
+        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == "na") {
+            mShutdownTxFnPtr();
         } else {
-            enterMuxWaitState(mCompositeState);
+            // If mux mode is in manual/standby/active mode, we should restart link prober. 
+            // If default route state is "ok", we should retart link prober.
+            mRestartTxFnPtr();
         }
-    } 
+    }
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -897,7 +897,7 @@ void LinkManagerStateMachine::handleDefaultRouteStateNotification(const std::str
 //
 // shutdown or restart link prober based on default route state
 //
-void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
+void LinkManagerStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
 {
     MUXLOGWARNING(boost::format("%s: default route state: %s") % mMuxPortConfig.getPortName() % mDefaultRouteState);
 

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -509,6 +509,15 @@ public:
     void handleDefaultRouteStateNotification(const std::string &routeState);
 
     /**
+     * @method shutdownOrRestartLinkProberOnDefaultRoute()
+     * 
+     * @brief  shutdown or restart link prober based on default route state
+     * 
+     * @return none
+     */
+    void shutdownOrRestartLinkProberOnDefaultRoute();
+
+    /**
      * @method handlePostPckLossRatioNotification
      * 
      * @brief handle get post pck loss ratio 
@@ -931,6 +940,32 @@ private:
     void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
 
     /**
+     * @method setShutdownTxFnPtr
+     * 
+     * @brief set shutdownTxFnPtr. This method is used for testing
+     * 
+     * @param shutdownTxFnPtr (in) pointer to new ShutdownTxFnPtr
+     * 
+     * @return none
+     */
+    void setShutdownTxFnPtr(boost::function<void ()> shutdownTxFnPtr) {
+        mShutdownTxFnPtr = shutdownTxFnPtr;
+    }
+
+    /**
+     * @method setRestartTxFnPtr
+     * 
+     * @brief set restartTxFnPtr. This method is used for testing
+     * 
+     * @param restartTxFnPtr (in) pointer to new restartTxFnPtr
+     * 
+     * @return none
+     */
+    void setRestartTxFnPtr(boost::function<void ()> restartTxFnPtr) {
+        mRestartTxFnPtr = restartTxFnPtr;
+    }
+
+    /**
      * @method setDecreaseIntervalFnPtr
      * 
      * @brief set new DecreaseIntervalFnPtr for the state machine. This method is used for testing
@@ -997,6 +1032,8 @@ private:
     boost::function<void ()> mResumeTxFnPtr;
     boost::function<void ()> mSendPeerSwitchCommandFnPtr;
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
+    boost::function<void ()> mShutdownTxFnPtr;
+    boost::function<void ()> mRestartTxFnPtr;
     boost::function<void (uint32_t switchTime_msec)> mDecreaseIntervalFnPtr;
     boost::function<void ()> mRevertIntervalFnPtr;
 
@@ -1008,6 +1045,8 @@ private:
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;
 
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
+
+    std::string mDefaultRouteState = "na";
 
     std::bitset<ComponentCount> mComponentInitState = {0};
     Label mLabel = Label::Uninitialized;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -272,7 +272,7 @@ void LinkProber::sendHeartbeat()
     MUXLOGTRACE(mMuxPortConfig.getPortName());
 
     // check if suspend timer is running
-    if (!mSuspendTx) {
+    if ((!mSuspendTx) && (!mShutdownTx)) {
         updateIcmpSequenceNo();
         boost::system::error_code errorCode;
         mStream.write_some(boost::asio::buffer(mTxBuffer.data(), mTxPacketSize), errorCode);
@@ -747,6 +747,20 @@ void LinkProber::resetIcmpPacketCounts()
         mIcmpUnknownEventCount,
         mIcmpPacketCount
     )));
+}
+
+void LinkProber::shutdownTxProbes()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mShutdownTx = true;
+}
+
+void LinkProber::restartTxProbes()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    mShutdownTx = false;
 }
 
 //

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -170,6 +170,24 @@ public:
     void resetIcmpPacketCounts();
 
     /**
+     * @method shutdownTxProbes
+     * 
+     * @brief stop sending ICMP ECHOREQUEST packets indefinitely.
+     * 
+     * @return none
+     */
+    void shutdownTxProbes();
+
+    /**
+     * @method restartTxProbes
+     * 
+     * @brief restart sending ICMP ECHOREQUEST packets
+     * 
+     * @return none
+     */
+    void restartTxProbes();
+
+    /**
      * @method decreaseProbeIntervalAfterSwitch
      *  
      * @brief adjust link prober interval to 10 ms after switchover to better measure the switchover overhead.
@@ -486,6 +504,7 @@ private:
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
 
     bool mSuspendTx = false;
+    bool mShutdownTx = false;
     bool mDecreaseProbingInterval = false;
 
     uint64_t mIcmpUnknownEventCount = 0;

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -138,6 +138,20 @@ void FakeLinkProber::resetIcmpPacketCounts()
     )));
 }
 
+void FakeLinkProber::shutdownTxProbes()
+{
+    MUXLOGINFO("");
+
+    mShutdownTxProbeCallCount++;
+}
+
+void FakeLinkProber::restartTxProbes()
+{
+    MUXLOGINFO("");
+    
+    mRestartTxProbeCallCount++;
+}
+
 void FakeLinkProber::decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec)
 {
     MUXLOGINFO("");

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -47,6 +47,8 @@ public:
     void resumeTxProbes();
     void sendPeerSwitchCommand();
     void resetIcmpPacketCounts();
+    void shutdownTxProbes();
+    void restartTxProbes();
     void decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
     void revertProbeIntervalAfterSwitchComplete();
 
@@ -59,6 +61,8 @@ public:
     uint32_t mSuspendTxProbeCallCount = 0;
     uint32_t mResumeTxProbeCallCount = 0;
     uint32_t mSendPeerSwitchCommand = 0;
+    uint32_t mShutdownTxProbeCallCount = 0;
+    uint32_t mRestartTxProbeCallCount = 0;
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -75,6 +75,12 @@ FakeMuxPort::FakeMuxPort(
     getLinkManagerStateMachine()->setSendPeerSwitchCommandFnPtr(
         boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
     );
+    getLinkManagerStateMachine()->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    getLinkManagerStateMachine()->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
     getLinkManagerStateMachine()->setDecreaseIntervalFnPtr(
         boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
     );

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1059,29 +1059,18 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
 {
     setMuxActive();
 
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 0);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
     postDefaultRouteEvent("na", 3);
-    
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 1);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 
 {
     setMuxStandby();
 
-    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 0);
-    postDefaultRouteEvent("ok", 2);
-
-    VALIDATE_STATE(Standby, Wait, Up);
-    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 1);
-
-    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
-    VALIDATE_STATE(Standby, Wait, Up);
-
-    handleMuxState("standby", 3);
-    VALIDATE_STATE(Standby, Standby, Up);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,0);
+    postDefaultRouteEvent("ok", 3);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -209,6 +209,12 @@ void MuxManagerTest::createPort(std::string port)
     linkManagerStateMachine->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );
+    linkManagerStateMachine->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachine->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
     linkManagerStateMachine->setDecreaseIntervalFnPtr(
         boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
     );


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Can't clear pick up this commit from master branch:
83004bf Jing Zhang      Tue Mar 29 11:33:18 2022 -0700  Shutdown ICMP heartbeats when default route state is missing and ToR is in `auto` mode (#44)

This PR is to address the expected behavior on default route states: 
1.	If in “manual” mode, default route state change should NOT trigger mux state change. 
2.	If in “auto” mode, default route state change to “na”, should trigger switchover to “standby”.
3.	Avoid switchovers to “active” if default route state remains “na”. 

Sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To handle default route state change. Make a healthy peer always takes over when self's missing default route state. 

#### How did you do it?
Shutdown heartbeats when default route state is missing and the mode is `auto`. 

Also make sure to restart the heartbeats when ToR enters manual mode or default route state is `ok`. 
#### How did you verify/test it?
Tested on dual testbeds. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->