### PR TITLE
Remove dh-systemd dependency for upgrading to bullseye

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,6 @@ Section: devel
 Priority: optional
 Maintainer: Tamer Ahmed <tamer.ahmed@microsoft.com>
 Build-Depends: debhelper (>= 8.0.0),
-               dh-systemd
 Standards-Version: 3.9.3
 Homepage: https://github.com/Azure/sonic-linkmgrd
 XS-Go-Import-Path: github.com/Azure/sonic-linkmgrd


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The dependency on `dh-systemd` is blocking upgrading docker-mux to `bullseye`. Removing it now to unblock. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->