### PR TITLE
Avoid proactively switching to `active` if default route is missing 

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -263,7 +263,7 @@ void MuxPort::handleMuxConfig(const std::string &config)
 //
 void MuxPort::handleDefaultRouteState(const std::string &routeState)
 {
-    MUXLOGDEBUG(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+    MUXLOGWARNING(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
     link_manager::LinkManagerStateMachineBase::DefaultRoute state = link_manager::LinkManagerStateMachineBase::DefaultRoute::OK;
     if (routeState == "na") {

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -265,11 +265,16 @@ void MuxPort::handleDefaultRouteState(const std::string &routeState)
 {
     MUXLOGDEBUG(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
+    link_manager::LinkManagerStateMachineBase::DefaultRoute state = link_manager::LinkManagerStateMachineBase::DefaultRoute::OK;
+    if (routeState == "na") {
+        state = link_manager::LinkManagerStateMachineBase::DefaultRoute::NA;
+    }
+
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
         &link_manager::LinkManagerStateMachineBase::handleDefaultRouteStateNotification,
         mLinkManagerStateMachinePtr.get(),
-        routeState
+        state
     )));
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -861,7 +861,7 @@ void ActiveStandbyStateMachine::handleSwitchActiveRequestEvent()
 //
 void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const DefaultRoute routeState)
 {
-    MUXLOGWARNING(boost::format("%s: state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (mDefaultRouteState == DefaultRoute::NA && routeState == DefaultRoute::OK) {
         initLinkProberState(mCompositeState);
@@ -878,7 +878,7 @@ void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const Defaul
 //
 void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
 {
-    MUXLOGWARNING(boost::format("%s: default route state: %s") % mMuxPortConfig.getPortName() % mDefaultRouteState);
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (mComponentInitState.all()) {
         if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == DefaultRoute::NA) {

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -741,7 +741,9 @@ void ActiveStandbyStateMachine::handlePeerLinkStateNotification(const link_state
     if(label == link_state::LinkState::Label::Down && ms(mCompositeState) == mux_state::MuxState::Standby) {
         CompositeState nextState = mCompositeState;
         enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
-        switchMuxState(nextState, mux_state::MuxState::Label::Active);
+        if (mDefaultRouteState == DefaultRoute::OK) {
+            switchMuxState(nextState, mux_state::MuxState::Label::Active);
+        }
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
     }
@@ -853,15 +855,15 @@ void ActiveStandbyStateMachine::handleSwitchActiveRequestEvent()
 }
 
 // 
-// ---> handleDefaultRouteStateNotification(const std::string &routeState);
+// ---> handleDefaultRouteStateNotification(const DefaultRoute routeState);
 // 
 // handle default route state notification from routeorch
 //
-void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const std::string &routeState)
+void ActiveStandbyStateMachine::handleDefaultRouteStateNotification(const DefaultRoute routeState)
 {
     MUXLOGWARNING(boost::format("%s: state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
-    if (mDefaultRouteState == "na" && routeState == "ok") {
+    if (mDefaultRouteState == DefaultRoute::NA && routeState == DefaultRoute::OK) {
         initLinkProberState(mCompositeState);
     }
     mDefaultRouteState = routeState;
@@ -879,7 +881,7 @@ void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
     MUXLOGWARNING(boost::format("%s: default route state: %s") % mMuxPortConfig.getPortName() % mDefaultRouteState);
 
     if (mComponentInitState.all()) {
-        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == "na") {
+        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == DefaultRoute::NA) {
             mShutdownTxFnPtr();
         } else {
             // If mux mode is in manual/standby/active mode, we should restart link prober. 
@@ -1160,7 +1162,9 @@ void ActiveStandbyStateMachine::LinkProberUnknownMuxStandbyLinkUpTransitionFunct
     enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
 
     // Start switching MUX to active state as we lost HB from active ToR
-    switchMuxState(nextState, mux_state::MuxState::Label::Active);
+    if (mDefaultRouteState == DefaultRoute::OK) {
+        switchMuxState(nextState, mux_state::MuxState::Label::Active);
+    }
     mDeadlineTimer.cancel();
     mWaitActiveUpCount = 0;
 }

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -382,7 +382,7 @@ public:
     void handleSwitchActiveRequestEvent();
 
     /**
-     * @method handleDefaultRouteStateNotification(const std::string &routeState)
+     * @method handleDefaultRouteStateNotification(const DefaultRoute routeState)
      * 
      * @brief handle default route state notification from routeorch
      * 
@@ -390,7 +390,7 @@ public:
      * 
      * @return none
     */
-    void handleDefaultRouteStateNotification(const std::string &routeState);
+    void handleDefaultRouteStateNotification(const DefaultRoute routeState);
 
     /**
      * @method shutdownOrRestartLinkProberOnDefaultRoute()
@@ -903,7 +903,7 @@ private:
 
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
-    std::string mDefaultRouteState = "na";
+    DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
 
     std::bitset<ComponentCount> mComponentInitState = {0};
 };

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -213,11 +213,11 @@ void LinkManagerStateMachineBase::handleSwitchActiveRequestEvent()
 }
 
 //
-// ---> handleDefaultRouteStateNotification(const std::string &routeState);
+// ---> handleDefaultRouteStateNotification(const DefaultRoute routeState);
 //
 // handle default route state notification from routeorch
 //
-void LinkManagerStateMachineBase::handleDefaultRouteStateNotification(const std::string &routeState)
+void LinkManagerStateMachineBase::handleDefaultRouteStateNotification(const DefaultRoute routeState)
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -96,6 +96,19 @@ public:
         Count
     };
 
+    /**
+     * @enum DefaultRoute 
+     * 
+     * @brief Default route co
+     */
+    enum class DefaultRoute {
+        Wait,
+        NA,
+        OK,
+
+        Count
+    };
+
     using CompositeState = std::tuple<link_prober::LinkProberState::Label,
                                       mux_state::MuxState::Label,
                                       link_state::LinkState::Label>;
@@ -340,7 +353,7 @@ public:
     virtual void handleSwitchActiveRequestEvent();
 
     /**
-     * @method handleDefaultRouteStateNotification(const std::string &routeState)
+     * @method handleDefaultRouteStateNotification(const DefaultRoute routeState)
      *
      * @brief handle default route state notification from routeorch
      *
@@ -348,7 +361,7 @@ public:
      *
      * @return none
      */
-    virtual void handleDefaultRouteStateNotification(const std::string& routeState);
+    virtual void handleDefaultRouteStateNotification(const DefaultRoute routeState);
 
     /**
      * @method shutdownOrRestartLinkProberOnDefaultRoute()

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -99,7 +99,7 @@ public:
     /**
      * @enum DefaultRoute 
      * 
-     * @brief Default route co
+     * @brief labels corresponding to each ToR default states
      */
     enum class DefaultRoute {
         Wait,

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -187,6 +187,7 @@ void LinkManagerStateMachineTest::handleMuxConfig(std::string config, uint32_t c
 void LinkManagerStateMachineTest::activateStateMachine()
 {
     mFakeMuxPort.activateStateMachine();
+    mFakeMuxPort.handleDefaultRouteState("ok");
 }
 
 void LinkManagerStateMachineTest::setMuxActive()
@@ -1060,17 +1061,13 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
     setMuxActive();
 
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
+
     postDefaultRouteEvent("na", 3);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
-}
 
-TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 
-{
-    setMuxStandby();
-
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,0);
     postDefaultRouteEvent("ok", 3);
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,2);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to avoid proactively switch to `active` if default route is missing. 

By proactively switching, it means:
* switches triggered by peer HB missing
* switches triggered by peer link state down 

sign-off: Jing Zhang zhangjing@microsoft.com  

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
ToR missing default route can't be `active healthy`. Toggling to active at this moment will only cause unwanted packet loss. 

#### How did you do it?
Avoid the switch. 

#### How did you verify/test it?
Passed all sonic-mgmt `dualtor_io` tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->