### PR TITLE
Add `ActiveActiveStateMachine` implementation

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -696,7 +696,6 @@ void DbInterface::processSoCIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> 
             boost::asio::ip::address ipAddress = boost::asio::ip::make_address(SoCIpAddress, errorCode);
             if (!errorCode) {
                 mMuxManagerPtr->addOrUpdateMuxPortSoCAddress(portName, ipAddress);
-                mSoCIpPortMap[ipAddress] = portName;
             } else {
                 MUXLOGFATAL(boost::format("%s: Received invalid SoC IP: %s, error code: %d") %
                     portName %

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1193,6 +1193,7 @@ void DbInterface::handleSwssNotification()
     swssSelect.addSelectable(&stateDbPortTable);
     swssSelect.addSelectable(&stateDbRouteTable);
     swssSelect.addSelectable(&stateDbMuxInfoTable);
+    swssSelect.addSelectable(&stateDbPeerMuxResponseTable);
     swssSelect.addSelectable(&netlinkNeighbor);
 
     while (mPollSwssNotifcation) {

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -51,7 +51,6 @@ namespace mux
 
 class MuxManager;
 using ServerIpPortMap = std::map<boost::asio::ip::address, std::string>;
-using SoCIpPortMap = std::map<boost::asio::ip::address, std::string>;
 
 /**
  *@class DbInterface
@@ -703,7 +702,6 @@ private:
     boost::asio::io_service::strand mStrand;
 
     ServerIpPortMap mServerIpPortMap;
-    SoCIpPortMap mSoCIpPortMap;
 };
 
 } /* namespace common */

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -49,6 +49,7 @@ namespace mux
 
 class MuxManager;
 using ServerIpPortMap = std::map<boost::asio::ip::address, std::string>;
+using SoCIpPortMap = std::map<boost::asio::ip::address, std::string>;
 
 /**
  *@class DbInterface
@@ -436,6 +437,28 @@ private:
     void getPortCableType(std::shared_ptr<swss::DBConnector> configDbConnector);
 
     /**
+    *@method processSoCIpAddress
+    *
+    *@brief process SoC IP address and builds a map of IP to port name
+    *
+    *@param entries   config_db MUX_CABLE entries
+    *
+    *@return none
+    */
+    inline void processSoCIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &entries);
+
+    /**
+    *@method getSoCIpAddress
+    *
+    *@brief retrieve SoC IP address and builds a map of IP to port name
+    *
+    *@param configDbConnector   config db connector
+    *
+    *@return none
+    */
+    void getSoCIpAddress(std::shared_ptr<swss::DBConnector> configDbConnector);
+
+    /**
     *@method processMuxPortConfigNotifiction
     *
     *@brief process MUX port configuration change notification
@@ -630,6 +653,7 @@ private:
     boost::asio::io_service::strand mStrand;
 
     ServerIpPortMap mServerIpPortMap;
+    SoCIpPortMap mSoCIpPortMap;
 };
 
 } /* namespace common */

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -45,7 +45,9 @@ class MuxManagerTest;
 namespace mux
 {
 #define MUX_CABLE_INFO_TABLE  "MUX_CABLE_INFO"
-#define LINK_PROBE_STATS_TABLE_NAME "LINK_PROBE_STATS" 
+#define LINK_PROBE_STATS_TABLE_NAME "LINK_PROBE_STATS"
+#define PEER_FORWARDING_STATE_COMMAND_TABLE "HW_FORWARDING_STATE_PEER"
+#define PEER_FORWARDING_STATE_RESPONSE_TABLE "HW_MUX_CABLE_TABLE_PEER"
 
 class MuxManager;
 using ServerIpPortMap = std::map<boost::asio::ip::address, std::string>;
@@ -133,6 +135,18 @@ public:
     *@return none
     */
     virtual void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
+
+    /**
+    *@method setPeerMuxState
+    *
+    *@brief set peer MUX state in APP DB for orchagent processing
+    *
+    *@param portName (in)   MUX/port name
+    *@param label (in)      label of target state
+    *
+    *@return none
+    */
+    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label);
 
     /**
     *@method probeMuxState
@@ -271,6 +285,18 @@ private:
     *@return none
     */
     void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label);
+
+    /**
+    *@method handleSetPeerMuxState
+    *
+    *@brief set peer MUX state in APP DB for orchagent processing
+    *
+    *@param portName (in)   MUX/port name
+    *@param label (in)      label of target state
+    *
+    *@return none
+    */
+    void handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label);
 
     /**
     *@method handleProbeMuxState
@@ -569,6 +595,28 @@ private:
     void handleMuxResponseNotifiction(swss::SubscriberStateTable &appdbPortTable);
 
     /**
+    *@method processPeerMuxResponseNotification
+    *
+    *@brief process peer MUX response (from xcvrd) notification
+    *
+    *@param entries (in) reference to app db peer mux response table entries
+    *
+    *@return none
+    */
+    inline void processPeerMuxResponseNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
+    /**
+    *@method handlePeerMuxResponseNotification
+    *
+    *@brief handles peer MUX response (from xcvrd) notification
+    *
+    *@param appdbPortTable (in) reference to app db peer mux response table
+    *
+    *@return none
+    */
+    void handlePeerMuxResponseNotification(swss::SubscriberStateTable &stateDbPeerMuxResponseTable);
+
+    /**
     *@method processMuxStateNotifiction
     *
     *@brief processes MUX state (from orchagent) notification
@@ -639,6 +687,8 @@ private:
     std::shared_ptr<swss::ProducerStateTable> mAppDbMuxTablePtr;
     // for communicating with the driver (probing the mux)
     std::shared_ptr<swss::Table> mAppDbMuxCommandTablePtr;
+    // for communicating with xcvrd to set peer mux state
+    std::shared_ptr<swss::Table> mAppDbPeerMuxCommandTablePtr;
     // for writing the current mux linkmgr health
     std::shared_ptr<swss::Table> mStateDbMuxLinkmgrTablePtr;
     // for writing mux metrics

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -317,6 +317,21 @@ void MuxManager::processProbeMuxState(const std::string &portName, const std::st
 }
 
 //
+// ---> processPeerMuxState(const std::string &portName, const std::string &peerMuxState);
+//
+// update peer MUX port state db notification
+//
+void MuxManager::processPeerMuxState(const std::string &portName, const std::string &peerMuxState)
+{
+    MUXLOGINFO(boost::format("%s: state db peer mux state: %s") % portName % peerMuxState);
+
+    PortMapIterator portMapIterator = mPortMap.find(portName);
+    if (portMapIterator != mPortMap.end()) {
+        portMapIterator->second->handlePeerMuxState(peerMuxState);
+    }
+}
+
+//
 // ---> addOrUpdateDefaultRouteState(boost::asio::ip::address& address, const std::string &routeState);
 //
 // update default route state based on state db notification
@@ -440,7 +455,7 @@ void MuxManager::handleProcessTerminate()
 //
 // generate known MAC address based on server ID
 //
-void generateServerMac(uint16_t serverId, std::array<uint8_t, ETHER_ADDR_LEN> &address)
+void MuxManager::generateServerMac(uint16_t serverId, std::array<uint8_t, ETHER_ADDR_LEN> &address)
 {
     if (serverId >= KNOWN_MAC_COUNT) {
         throw std::range_error("Out of MAC address range");

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -201,6 +201,8 @@ void MuxManager::updatePortCableType(const std::string &portName, const std::str
     common::MuxPortConfig::PortCableType portCableType;
     if (cableType == "active-standby") {
         portCableType = common::MuxPortConfig::PortCableType::ActiveStandby;
+    } else if (cableType == "active-active") {
+        portCableType = common::MuxPortConfig::PortCableType::ActiveActive;
     } else {
         MUXLOGERROR(
             boost::format(

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -280,10 +280,8 @@ void MuxManager::processGetServerMacAddress(
 {
     MUXLOGDEBUG(portName);
 
-    common::MuxPortConfig::PortCableType portCableType = getMuxPortCableType(portName);
     PortMapIterator portMapIterator = mPortMap.find(portName);
-    // only allow ports in active-standby mode to react to mac address changes
-    if (portMapIterator != mPortMap.end() && portCableType == common::MuxPortConfig::PortCableType::ActiveStandby) {
+    if (portMapIterator != mPortMap.end()) {
         portMapIterator->second->handleGetServerMacAddress(address);
     }
 }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -139,9 +139,36 @@ void MuxManager::addOrUpdateMuxPort(const std::string &portName, boost::asio::ip
     MUXLOGWARNING(boost::format("%s: server IP: %s") % portName % address);
 
     std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
+    common::MuxPortConfig::PortCableType portCableType = getMuxPortCableType(portName);
 
     if (address.is_v4()) {
-        muxPortPtr->handleBladeIpv4AddressUpdate(address);
+        if (portCableType == common::MuxPortConfig::PortCableType::ActiveStandby) {
+            // notify server IP address for ports in active-standby cable type
+            muxPortPtr->handleBladeIpv4AddressUpdate(address);
+        }
+
+    } else if (address.is_v6()) {
+        // handle IPv6 probing
+    }
+}
+
+//
+// ---> addOrUpdateMuxPortSoCAddress(const std::string &portName, boost::asio::ip::address address);
+//
+// update MUX port SoC IPv4 Address. If port is not found, create new MuxPort object
+//
+void MuxManager::addOrUpdateMuxPortSoCAddress(const std::string &portName, boost::asio::ip::address address)
+{
+    MUXLOGWARNING(boost::format("%s: SoC IP: %s") % portName % address);
+
+    std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
+    common::MuxPortConfig::PortCableType portCableType = getMuxPortCableType(portName);
+
+    if (address.is_v4()) {
+        if (portCableType == common::MuxPortConfig::PortCableType::ActiveActive) {
+            // notify NiC IP address for ports in active-active cable type
+            muxPortPtr->handleSoCIpv4AddressUpdate(address);
+        }
     } else if (address.is_v6()) {
         // handle IPv6 probing
     }

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -240,6 +240,18 @@ public:
     void addOrUpdateMuxPort(const std::string &portName, boost::asio::ip::address address);
 
     /**
+    *@method addOrUpdateMuxPortSoCAddress
+    *
+    *@brief update MUX port SoC IPv4 Address. If port is not found, create new MuxPort object
+    *
+    *@param portName (in)   Mux port name
+    *@param address (in)    SoC IP address
+    *
+    *@return none
+    */
+    void addOrUpdateMuxPortSoCAddress(const std::string &portName, boost::asio::ip::address address);
+
+    /**
     *@method updateMuxPortConfig
     *
     *@brief update MUX port server/blade IPv4 Address. If port is not found, create new MuxPort object

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -47,6 +47,9 @@ using PortMapIterator = PortMap::iterator;
 using PortCableTypeMap = std::map<std::string, common::MuxPortConfig::PortCableType>;
 using PortCableTypeMapIterator = PortCableTypeMap::iterator;
 
+const std::array<uint8_t, ETHER_ADDR_LEN> KNOWN_MAC_START = {0x04, 0x27, 0x28, 0x7a, 0x00, 0x00};
+const size_t KNOWN_MAC_COUNT = 1024;
+
 /**
  *@class MuxManager
  *
@@ -414,6 +417,15 @@ private:
     *@return none
     */
     void handleProcessTerminate();
+
+    /**
+    *@method generateServerMac
+    *
+    *@brief generate Server MAC for port in active-active cable type
+    *
+    *@return none
+    */
+    void generateServerMac(uint16_t serverId, std::array<uint8_t, ETHER_ADDR_LEN> &address);
 
 private:
     friend class test::MuxManagerTest;

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -362,6 +362,18 @@ public:
     void processProbeMuxState(const std::string &portName, const std::string &muxState);
 
     /**
+    *@method processPeerMuxState
+    *
+    *@brief update peer MUX port state db notification
+    *
+    *@param portName        (in)   Mux port name
+    *@param peerMuxState    (in)   Peer mux port state
+    *
+    *@return none
+    */
+    void processPeerMuxState(const std::string &portName, const std::string &peerMuxState);
+
+    /**
      * @method addOrUpdateDefaultRouteState
      * 
      * @brief update default route state based on state db notification

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -273,6 +273,32 @@ void MuxPort::handleMuxConfig(const std::string &config)
     )));
 }
 
+//
+// ---> handlePeerMuxState(const std::string &peerMuxState);
+//
+// handles peer MUX state updates
+//
+void MuxPort::handlePeerMuxState(const std::string &peerMuxState)
+{
+    MUXLOGDEBUG(boost::format("port: %s, state db peer mux state: %s") % mMuxPortConfig.getPortName() % peerMuxState);
+
+    mux_state::MuxState::Label label = mux_state::MuxState::Label::Unknown;
+    if (peerMuxState == "active") {
+        label = mux_state::MuxState::Label::Active;
+    } else if (peerMuxState == "standby") {
+        label = mux_state::MuxState::Label::Standby;
+    } else if (peerMuxState == "error") {
+        label = mux_state::MuxState::Label::Error;
+    }
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handlePeerMuxStateNotification,
+        mLinkManagerStateMachinePtr.get(),
+        label
+    )));
+}
+
 // 
 // ---> handleDefaultRouteState(const std::string &routeState);
 // 

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -94,6 +94,23 @@ void MuxPort::handleBladeIpv4AddressUpdate(boost::asio::ip::address address)
 }
 
 //
+// ---> handleSoCIpv4AddressUpdate(boost::asio::ip::address address);
+//
+// handles SoC IP address update for port in active-active cable type
+//
+void MuxPort::handleSoCIpv4AddressUpdate(boost::asio::ip::address address)
+{
+    MUXLOGDEBUG(boost::format("port: %s") % mMuxPortConfig.getPortName());
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handleSwssSoCIpv4AddressUpdate,
+        mLinkManagerStateMachinePtr.get(),
+        address
+    )));
+}
+
+//
 // ---> handleLinkState(const std::string &linkState);
 //
 // handles link state updates

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -71,12 +71,23 @@ MuxPort::MuxPort(
     mStrand(ioService)
 {
     assert(dbInterfacePtr != nullptr);
-    if (portCableType == common::MuxPortConfig::PortCableType::ActiveStandby) {
-        mLinkManagerStateMachinePtr = std::make_shared<link_manager::ActiveStandbyStateMachine>(
-            this,
-            mStrand,
-            mMuxPortConfig
-        );
+    switch (portCableType) {
+        case common::MuxPortConfig::PortCableType::ActiveActive:
+            mLinkManagerStateMachinePtr = std::make_shared<link_manager::ActiveActiveStateMachine>(
+                this,
+                mStrand,
+                mMuxPortConfig
+            );
+            break;
+        case common::MuxPortConfig::PortCableType::ActiveStandby:
+            mLinkManagerStateMachinePtr = std::make_shared<link_manager::ActiveStandbyStateMachine>(
+                this,
+                mStrand,
+                mMuxPortConfig
+            );
+            break;
+        default:
+            break;
     }
     assert(mLinkManagerStateMachinePtr.get() != nullptr);
 }

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -212,7 +212,18 @@ public:
     *
     *@return none
     */
-     void handleBladeIpv4AddressUpdate(boost::asio::ip::address addres);
+    void handleBladeIpv4AddressUpdate(boost::asio::ip::address addres);
+
+    /**
+    *@method handleSoCIpv4AddressUpdate
+    *
+    *@brief update SoC IPv4 Address
+    *
+    *@param addres (in)  server/blade IP address
+    *
+    *@return none
+    */
+    void handleSoCIpv4AddressUpdate(boost::asio::ip::address addres);
 
     /**
     *@method handleLinkState

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -114,6 +114,17 @@ public:
     inline void setMuxState(mux_state::MuxState::Label label) {mDbInterfacePtr->setMuxState(mMuxPortConfig.getPortName(), label);};
 
     /**
+    *@method setPeerMuxState
+    *
+    *@brief set peer MUX state in APP DB for orchagent processing
+    *
+    *@param label (in)      label of target state
+    *
+    *@return none
+    */
+    inline void setPeerMuxState(mux_state::MuxState::Label label) { mDbInterfacePtr->setPeerMuxState(mMuxPortConfig.getPortName(), label); };
+
+    /**
     *@method getMuxState
     *
     *@brief retrieve the current MUX state
@@ -312,6 +323,18 @@ public:
     *@return none
     */
     void handleMuxConfig(const std::string &config);
+
+    /**
+    *@method handlePeerMuxState
+    *
+    *@brief handles peer MUX state updates
+    *
+    *@param peerMuxState (in)           peer MUX state
+    *
+    *@return none
+    */
+    void handlePeerMuxState(const std::string &peerMuxState);
+
 
     /**
      * @method handleDefaultRouteState(const std::string &routeState)

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -29,6 +29,7 @@
 
 #include "link_prober/LinkProber.h"
 #include "link_prober/LinkProberStateMachineBase.h"
+#include "link_manager/LinkManagerStateMachineActiveActive.h"
 #include "link_manager/LinkManagerStateMachineActiveStandby.h"
 
 #include "common/MuxPortConfig.h"

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -204,6 +204,17 @@ public:
     inline void setServerIpv4Address(const boost::asio::ip::address &address) {mMuxPortConfig.setBladeIpv4Address(address);};
 
     /**
+    *@method setServerMacAddress
+    *
+    *@brief setter for server MAC address
+    *
+    *@param address (in) server MAC address
+    *
+    *@return none
+    */
+    inline void setServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setBladeMacAddress(address);};
+
+    /**
     *@method handleBladeIpv4AddressUpdate
     *
     *@brief update server/blade IPv4 Address

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -33,6 +33,7 @@
 namespace link_manager {
 class LinkManagerStateMachineBase;
 class ActiveStandbyStateMachine;
+class ActiveActiveStateMachine;
 }
 
 namespace link_prober {
@@ -114,6 +115,7 @@ public:
 private:
     friend class link_manager::LinkManagerStateMachineBase;
     friend class link_manager::ActiveStandbyStateMachine;
+    friend class link_manager::ActiveActiveStateMachine;
     friend class link_prober::LinkProberStateMachineActiveStandby;
     friend class link_prober::LinkProberStateMachineBase;
     friend class link_prober::LinkProberStateMachineActiveActive;

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -112,6 +112,15 @@ public:
     */
     boost::asio::io_service::strand& getStrand() {return mStrand;};
 
+    /**
+    *@method getMuxPortConfig
+    *
+    *@brief getter MuxPortConfig object
+    *
+    *@return reference to MuxPortConfig object
+    */
+    const MuxPortConfig& getMuxPortConfig() const {return mMuxPortConfig;};
+
 private:
     friend class link_manager::LinkManagerStateMachineBase;
     friend class link_manager::ActiveStandbyStateMachine;
@@ -142,15 +151,6 @@ private:
     *@return current state of the state machine
     */
     State* getCurrentState() {return mCurrentState;};
-
-    /**
-    *@method getMuxPortConfig
-    *
-    *@brief getter MuxPortConfig object
-    *
-    *@return reference to MuxPortConfig object
-    */
-    const MuxPortConfig& getMuxPortConfig() const {return mMuxPortConfig;};
 
 private:
     boost::asio::io_service::strand mStrand;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1,0 +1,846 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <boost/bind/bind.hpp>
+
+#include "link_manager/LinkManagerStateMachineActiveActive.h"
+#include "common/MuxLogger.h"
+#include "common/MuxException.h"
+#include "MuxPort.h"
+
+namespace link_manager
+{
+
+constexpr auto MAX_BACKOFF_FACTOR = 32;
+
+//
+// ---> ActiveActiveStateMachine(
+//          mux::MuxPort *muxPortPtr,
+//          boost::asio::io_service::strand &strand,
+//          common::MuxPortConfig &muxPortConfig
+//      )
+//
+// Construct a new Active Active State Machine object
+//
+ActiveActiveStateMachine::ActiveActiveStateMachine(
+    mux::MuxPort *muxPortPtr,
+    boost::asio::io_service::strand &strand,
+    common::MuxPortConfig &muxPortConfig
+)
+    : LinkManagerStateMachineBase(
+          muxPortPtr,
+          strand,
+          muxPortConfig,
+          {link_prober::LinkProberState::Label::Wait,
+           mux_state::MuxState::Label::Wait,
+           link_state::LinkState::Label::Down}
+      ),
+      mWaitTimer(strand.context()),
+      mPeerWaitTimer(strand.context())
+{
+    assert(muxPortPtr != nullptr);
+    mMuxPortPtr->setMuxLinkmgrState(mLabel);
+    initializeTransitionFunctionTable();
+}
+
+//
+// ---> activateStateMachine();
+//
+// activate the state machine by starting the link prober.
+//
+void ActiveActiveStateMachine::activateStateMachine()
+{
+    if (mComponentInitState.all()) {
+        // TODO: use known mac address
+        std::array<uint8_t, ETHER_ADDR_LEN> macAddress = mMuxPortConfig.getBladeMacAddress();
+        std::array<char, 3 *ETHER_ADDR_LEN> macAddressStr = {0};
+
+        snprintf(
+            macAddressStr.data(), macAddressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",
+            macAddress[0], macAddress[1], macAddress[2], macAddress[3], macAddress[4], macAddress[5]
+        );
+
+        MUXLOGWARNING(
+            boost::format("%s: MUX port link prober initialized with server IP: %s, server MAC: %s") %
+            mMuxPortConfig.getPortName() %
+            mMuxPortConfig.getBladeIpv4Address().to_string() %
+            macAddressStr.data()
+        );
+        // make link prober state match the MUX state since the state machine is activated for the first time
+        CompositeState nextState = mCompositeState;
+        initLinkProberState(nextState);
+        LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+        mCompositeState = nextState;
+
+        mInitializeProberFnPtr();
+        mStartProbingFnPtr();
+
+        updateMuxLinkmgrState();
+    }
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+|  db event handlers
+---------------------------------------------------------------------------------------------------------------*/
+
+//
+// ---> handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address);
+//
+// initialize the link prober component. Note if this is the last component to be initialized,
+// state machine will be activated
+//
+void ActiveActiveStateMachine::handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address)
+{
+    if (!mComponentInitState.test(LinkProberComponent)) {
+        mMuxPortConfig.setBladeIpv4Address(address);
+
+        try {
+            mLinkProberPtr = std::make_shared<link_prober::LinkProber>(
+                mMuxPortConfig,
+                getStrand().context(),
+                mLinkProberStateMachinePtr.get()
+            );
+            mInitializeProberFnPtr = boost::bind(
+                &link_prober::LinkProber::initialize, mLinkProberPtr.get()
+            );
+            mStartProbingFnPtr = boost::bind(
+                &link_prober::LinkProber::startProbing, mLinkProberPtr.get()
+            );
+            mProbePeerTorFnPtr = boost::bind(
+                &link_prober::LinkProber::probePeerTor, mLinkProberPtr.get()
+            );
+            mSuspendTxFnPtr = boost::bind(
+                &link_prober::LinkProber::suspendTxProbes, mLinkProberPtr.get(), boost::placeholders::_1
+            );
+            mResumeTxFnPtr = boost::bind(
+                &link_prober::LinkProber::resumeTxProbes, mLinkProberPtr.get()
+            );
+            mShutdownTxFnPtr = boost::bind(
+                &link_prober::LinkProber::shutdownTxProbes, mLinkProberPtr.get()
+            );
+            mRestartTxFnPtr = boost::bind(
+                &link_prober::LinkProber::restartTxProbes, mLinkProberPtr.get()
+            );
+
+            setComponentInitState(LinkProberComponent);
+
+            activateStateMachine();
+        } catch (const std::bad_alloc &ex) {
+            std::ostringstream errMsg;
+            errMsg << "Failed allocate memory. Exception details: " << ex.what();
+
+            throw MUX_ERROR(BadAlloc, errMsg.str());
+        }
+    } else if (address != mMuxPortConfig.getBladeIpv4Address()) {
+        mMuxPortConfig.setBladeIpv4Address(address);
+        mUpdateEthernetFrameFnPtr();
+    }
+}
+
+//
+// ---> handleMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle MUX state notification
+//
+void ActiveActiveStateMachine::handleMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGWARNING(boost::format("%s: state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    mWaitTimer.cancel();
+
+    if (mComponentInitState.all()) {
+        if (mMuxStateMachine.getWaitStateCause() != mux_state::WaitState::WaitStateCause::SwssUpdate) {
+            MUXLOGWARNING(boost::format("%s: Received unsolicited MUX state change notification!") % mMuxPortConfig.getPortName());
+        }
+        mProbePeerTorFnPtr();
+        mResumeTxFnPtr();
+        postMuxStateEvent(label);
+    } else {
+        if (label == mux_state::MuxState::Unknown) {
+            // probe xcvrd to read the current mux state
+            probeMuxState();
+        }
+        enterMuxState(mCompositeState, label);
+        setComponentInitState(MuxStateComponent);
+        activateStateMachine();
+    }
+}
+
+//
+// ---> handleSwssLinkStateNotification(const link_state::LinkState::Label label);
+//
+// handle link state notification
+//
+void ActiveActiveStateMachine::handleSwssLinkStateNotification(const link_state::LinkState::Label label)
+{
+    MUXLOGINFO(boost::format("%s: state db link state: %s") % mMuxPortConfig.getPortName() % mLinkStateName[label]);
+
+    if (mComponentInitState.all()) {
+        if (label == link_state::LinkState::Label::Up) {
+            mLinkStateMachine.postLinkStateEvent(link_state::LinkStateMachine::getUpEvent());
+        } else if (label == link_state::LinkState::Label::Down) {
+            mLinkStateMachine.postLinkStateEvent(link_state::LinkStateMachine::getDownEvent());
+        }
+    } else {
+        enterLinkState(mCompositeState, label);
+        setComponentInitState(LinkStateComponent);
+        activateStateMachine();
+    }
+}
+
+//
+// ---> handleMuxConfigNotification(const common::MuxPortConfig::Mode mode);
+//
+// handle MUX configuration change notification
+//
+void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPortConfig::Mode mode)
+{
+    if (mComponentInitState.all()) {
+        if (mode == common::MuxPortConfig::Mode::Active &&
+            ms(mCompositeState) != mux_state::MuxState::Label::Active) {
+            CompositeState nextState = mCompositeState;
+            switchMuxState(nextState, mux_state::MuxState::Label::Active);
+            LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+            mCompositeState = nextState;
+        } else if (mode == common::MuxPortConfig::Mode::Standby && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
+            CompositeState nextState = mCompositeState;
+            switchMuxState(nextState, mux_state::MuxState::Label::Active);
+            LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+            mCompositeState = nextState;
+        } else {
+            mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
+            probeMuxState();
+        }
+
+        updateMuxLinkmgrState();
+    }
+
+    mMuxPortConfig.setMode(mode);
+}
+
+//
+// ---> handleProbeMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle probe MUX state notification
+//
+void ActiveActiveStateMachine::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGWARNING(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    mWaitTimer.cancel();
+
+    if (mComponentInitState.all()) {
+        if (mMuxStateMachine.getWaitStateCause() != mux_state::WaitState::WaitStateCause::DriverUpdate) {
+            MUXLOGWARNING(
+                boost::format("%s: Received unsolicited MUX state probe notification!") %
+                mMuxPortConfig.getPortName()
+            );
+        }
+
+        postMuxStateEvent(label);
+    } else {
+        if (label == mux_state::MuxState::Unknown) {
+            MUXLOGWARNING(
+                boost::format("%s: xcvrd reports MUX state as '%s' during init. phase! Is there a functioning MUX?") %
+                mMuxPortConfig.getPortName() %
+                mMuxStateName[label]
+            );
+            probeMuxState();
+        }
+
+        enterMuxState(mCompositeState, label);
+        setComponentInitState(MuxStateComponent);
+        activateStateMachine();
+    }
+}
+
+//
+// ---> handlePeerMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle peer MUX state notification
+//
+void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGWARNING(boost::format("%s: state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    mPeerWaitTimer.cancel();
+    enterPeerMuxState(label);
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+|  link prober event handlers
+---------------------------------------------------------------------------------------------------------------*/
+
+//
+// ---> handleSuspendTimerExpiry();
+//
+// handle completion of sending switch command to peer ToR
+//
+void ActiveActiveStateMachine::handleSuspendTimerExpiry()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    mResumeTxFnPtr();
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+|  state handlers
+---------------------------------------------------------------------------------------------------------------*/
+
+//
+// ---> handleStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state);
+//
+// handles LinkProberEvent
+//
+void ActiveActiveStateMachine::handleStateChange(
+    LinkProberEvent &event,
+    link_prober::LinkProberState::Label state
+)
+{
+    if ((dynamic_cast<link_prober::LinkProberState *>(mLinkProberStateMachinePtr->getCurrentState()))->getStateLabel() == state) {
+        MUXLOGWARNING(
+            boost::format("%s: Received link prober event, new state: %s") %
+            mMuxPortConfig.getPortName() %
+            mLinkProberStateName[state]
+        );
+
+        CompositeState nextState = mCompositeState;
+        ps(nextState) = state;
+        mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
+        LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+        mCompositeState = nextState;
+    }
+
+    updateMuxLinkmgrState();
+}
+
+//
+// ---> handleStateChange(MuxStateEvent &event, mux_state::MuxState::Label state);
+//
+// handles MuxStateEvent
+//
+void ActiveActiveStateMachine::handleStateChange(
+    MuxStateEvent &event,
+    mux_state::MuxState::Label state
+)
+{
+    if ((dynamic_cast<mux_state::MuxState *>(mMuxStateMachine.getCurrentState()))->getStateLabel() == state) {
+        MUXLOGWARNING(
+            boost::format("%s: Received mux state event, new state: %s") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[state]
+        );
+
+        CompositeState nextState = mCompositeState;
+        ms(nextState) = state;
+        mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
+        LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+        mCompositeState = nextState;
+    }
+
+    updateMuxLinkmgrState();
+}
+
+//
+// ---> handleStateChange(LinkStateEvent &event, link_state::LinkState::Label state);
+//
+// handles LinkStateEvent
+//
+void ActiveActiveStateMachine::handleStateChange(
+    LinkStateEvent &event,
+    link_state::LinkState::Label state
+)
+{
+    if ((dynamic_cast<link_state::LinkState *>(mLinkStateMachine.getCurrentState()))->getStateLabel() == state) {
+        MUXLOGWARNING(
+            boost::format("%s: Received link state event, new state: %s") %
+            mMuxPortConfig.getPortName() %
+            mLinkStateName[state]
+        );
+
+        CompositeState nextState = mCompositeState;
+        ls(nextState) = state;
+        if (ls(mCompositeState) == link_state::LinkState::Down && ls(nextState) == link_state::LinkState::Up) {
+            initLinkProberState(nextState);
+            initPeerLinkProberState();
+        } else if (ls(mCompositeState) == link_state::LinkState::Up && ls(nextState) == link_state::LinkState::Down && ms(mCompositeState) == mux_state::MuxState::Label::Active) {
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+        } else {
+            mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
+        }
+        LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+        mCompositeState = nextState;
+    }
+
+    updateMuxLinkmgrState();
+}
+
+//
+// ---> handlePeerStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state);
+//
+// handles peer LinkProberEvent
+//
+void ActiveActiveStateMachine::handlePeerStateChange(
+    LinkProberEvent &event,
+    link_prober::LinkProberState::Label state
+)
+{
+    if ((dynamic_cast<link_prober::LinkProberState *>(mLinkProberStateMachinePtr->getCurrentState()))->getStateLabel() == state) {
+        MUXLOGWARNING(
+            boost::format("%s: Received peer link prober event, new state: %s") %
+            mMuxPortConfig.getPortName() %
+            mLinkProberStateName[state]
+        );
+        if (mLabel == Label::Healthy) {
+            switch (state) {
+                case link_prober::LinkProberState::Label::PeerActive: {
+                    enterPeerLinkProberState(state);
+                    break;
+                }
+                case link_prober::LinkProberState::Label::PeerUnknown: {
+                    enterPeerLinkProberState(state);
+                    switchPeerMuxState(mux_state::MuxState::Label::Standby);
+                    break;
+                }
+                default:
+                    break;
+            }
+        } else {
+            enterPeerLinkProberState(state);
+        }
+    }
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+ |  state transition functions
+ ---------------------------------------------------------------------------------------------------------------*/
+
+//
+// ---> initializeTransitionFunctionTable();
+//
+// initialize transition function table
+//
+void ActiveActiveStateMachine::initializeTransitionFunctionTable()
+{
+    MUXLOGWARNING("Initializing State Transition Table...");
+    LinkManagerStateMachineBase::initializeTransitionFunctionTable();
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Active]
+                           [mux_state::MuxState::Label::Standby]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Active]
+                           [mux_state::MuxState::Label::Unknown]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Unknown]
+                           [mux_state::MuxState::Label::Active]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Active]
+                           [mux_state::MuxState::Label::Unknown]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Unknown]
+                           [mux_state::MuxState::Label::Unknown]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Active]
+                           [mux_state::MuxState::Label::Error]
+                           [link_state::LinkState::Label::Up] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberActiveMuxErrorLinkUpTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+}
+
+//
+// ---> LinkProberActiveMuxStandbyLinkUpTransitionFunction(CompositeState &nextState);
+//
+// transition function when entering {LinkProberActive, MuxStandby, LinkUp} state
+//
+void ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    switchMuxState(nextState, mux_state::MuxState::Label::Active);
+}
+
+// void ActiveActiveStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFunction(CompositeState &nextState)
+// {
+//     MUXLOGINFO(mMuxPortConfig.getPortName());
+//     if (ps(mCompositeState) != link_prober::LinkProberState::Active) {
+//         switchMuxState(nextState, mux_state::MuxState::Label::Active);
+//     } else {
+//         probeMuxState();
+//     }
+// }
+
+//
+// ---> LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState);
+//
+// transition function when entering {LinkProberUnknown, MuxActive, LinkUp} state
+//
+void ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+}
+
+//
+// ---> LinkProberActiveMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
+//
+// transition function when entering {LinkProberActive, MuxUnknown, LinkUp} state
+//
+void ActiveActiveStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    probeMuxState();
+}
+
+//
+// ---> LinkProberUnknownMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
+//
+// transition function when entering {LinkProberUnknown, MuxUnknown, LinkUp} state
+//
+void ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkUpTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    probeMuxState();
+}
+
+//
+// ---> LinkProberActiveMuxErrorLinkUpTransitionFunction(CompositeState &nextState);
+//
+// transition function when entering {LinkProberActive, MuxError, LinkUp} state
+//
+void ActiveActiveStateMachine::LinkProberActiveMuxErrorLinkUpTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    probeMuxState();
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+ |  utility methods to check/modify state
+ ---------------------------------------------------------------------------------------------------------------*/
+
+//
+// ---> setLabel(Label label);
+//
+// sets linkmgr State db state
+//
+void ActiveActiveStateMachine::setLabel(Label label)
+{
+    if (mLabel != label) {
+        mLabel = label;
+        mMuxPortPtr->setMuxLinkmgrState(label);
+
+        MUXLOGWARNING(
+            boost::format("%s: Linkmgrd state is: %s %s") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[ms(mCompositeState)] %
+            mLinkHealthName[static_cast<int>(label)]
+        );
+    }
+}
+
+//
+// ---> enterLinkProberState(CompositeState &nextState, link_prober::LinkProberState::Label label);
+//
+// force LinkProberState to switch state
+//
+void ActiveActiveStateMachine::enterLinkProberState(
+    CompositeState &nextState,
+    link_prober::LinkProberState::Label label
+)
+{
+    mLinkProberStateMachinePtr->enterState(label);
+    ps(nextState) = label;
+}
+
+//
+// ---> enterMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
+//
+// force MuxState to switch state
+//
+void ActiveActiveStateMachine::enterMuxState(
+    CompositeState &nextState,
+    mux_state::MuxState::Label label
+)
+{
+    mMuxStateMachine.enterState(label);
+    ms(nextState) = label;
+}
+
+//
+// ---> enterLinkState(CompositeState &nextState, link_state::LinkState::Label label);
+//
+// force LinkState to switch state
+//
+void ActiveActiveStateMachine::enterLinkState(
+    CompositeState &nextState,
+    link_state::LinkState::Label label
+)
+{
+    mLinkStateMachine.enterState(label);
+    ls(nextState) = label;
+}
+
+//
+// ---> enterPeerMuxState(mux_state::MuxState::Label label);
+//
+// force peer MuxState to switch state
+//
+void ActiveActiveStateMachine::enterPeerMuxState(mux_state::MuxState::Label label)
+{
+    mPeerMuxState = label;
+}
+
+//
+// ---> enterPeerLinkProberState(link_prober::LinkProberState::Label label);
+//
+// force peer LinkProberState to switch state
+//
+void ActiveActiveStateMachine::enterPeerLinkProberState(link_prober::LinkProberState::Label label)
+{
+    mPeerLinkProberState = label;
+}
+
+//
+// ---> switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label, bool forceSwitch);
+//
+// switch MUX to the target state
+//
+void ActiveActiveStateMachine::switchMuxState(
+    CompositeState &nextState,
+    mux_state::MuxState::Label label
+)
+{
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
+        MUXLOGWARNING(
+            boost::format("%s: Switching MUX state to '%s'") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[label]
+        );
+        if (label == mux_state::MuxState::Label::Standby) {
+            // suspend heartbeat to help peer ToR to toggle
+            mSuspendTxFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec());
+        }
+        enterMuxState(nextState, label);
+        mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
+        mMuxPortPtr->setMuxState(label);
+        startMuxWaitTimer();
+    } else {
+        probeMuxState();
+    }
+}
+
+//
+// ---> switchPeerMuxState(CompositeState &nextState, mux_state::MuxState::Label label, bool forceSwitch);
+//
+// switch peer MUX to the target state
+//
+void ActiveActiveStateMachine::switchPeerMuxState(mux_state::MuxState::Label label)
+{
+    MUXLOGWARNING(
+        boost::format("%s: Switching peer MUX state to '%s'") %
+        mMuxPortConfig.getPortName() %
+        mMuxStateName[label]
+    );
+    enterPeerMuxState(label);
+    mMuxPortPtr->setPeerMuxState(label);
+    startPeerMuxWaitTimer();
+}
+
+//
+// ---> probeMuxState();
+//
+// probe mux state
+//
+void ActiveActiveStateMachine::probeMuxState()
+{
+    mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
+    mMuxPortPtr->probeMuxState();
+    startMuxWaitTimer();
+}
+
+//
+// ---> updateMuxLinkmgrState();
+//
+// update State DB MUX LinkMgr state
+//
+void ActiveActiveStateMachine::updateMuxLinkmgrState()
+{
+    Label label = Label::Unhealthy;
+    if (ls(mCompositeState) == link_state::LinkState::Label::Up && ps(mCompositeState) == link_prober::LinkProberState::Label::Active && ms(mCompositeState) == mux_state::MuxState::Label::Active) {
+        label = Label::Healthy;
+    }
+    setLabel(label);
+}
+
+//
+// ---> initLinkProberState(CompositeState &compositeState);
+//
+// initialize LinkProberState when configuring the composite state machine
+//
+void ActiveActiveStateMachine::initLinkProberState(CompositeState &compositeState)
+{
+    switch (ms(compositeState)) {
+        case mux_state::MuxState::Label::Active:
+            enterLinkProberState(compositeState, link_prober::LinkProberState::Label::Active);
+            break;
+        case mux_state::MuxState::Label::Standby:
+            enterLinkProberState(compositeState, link_prober::LinkProberState::Label::Unknown);
+            break;
+        case mux_state::MuxState::Label::Unknown:
+            enterLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            break;
+        case mux_state::MuxState::Label::Error:
+            enterLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            break;
+        default:
+            break;
+    }
+}
+
+//
+// ---> initPeerLinkProberState();
+//
+// initialize peer LinkProberState when configuring the composite state machine
+//
+void ActiveActiveStateMachine::initPeerLinkProberState()
+{
+    switch (mPeerMuxState) {
+        case mux_state::MuxState::Label::Active:
+            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::PeerActive);
+            break;
+        case mux_state::MuxState::Label::Standby:
+            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::PeerUnknown);
+            break;
+        case mux_state::MuxState::Label::Unknown:
+            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            break;
+        case mux_state::MuxState::Label::Error:
+            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            break;
+        default:
+            break;
+    }
+}
+
+//
+// ---> startMuxWaitTimer(uint32_t factor);
+//
+// start a timer to wait for mux state notification from xcvrd/orchagent
+//
+void ActiveActiveStateMachine::startMuxWaitTimer(uint32_t factor)
+{
+    mWaitTimer.expires_from_now(boost::posix_time::milliseconds(
+        factor * mMuxPortConfig.getNegativeStateChangeRetryCount() * mMuxPortConfig.getTimeoutIpv4_msec()
+    ));
+    mWaitTimer.async_wait(getStrand().wrap(boost::bind(
+        &ActiveActiveStateMachine::handleMuxWaitTimeout,
+        this,
+        boost::asio::placeholders::error
+    )));
+}
+
+//
+// ---> handleMuxWaitTimeout(boost::system::error_code errorCode);
+//
+// handle when xcrvrd/orchagent has timed out responding mux state
+//
+void ActiveActiveStateMachine::handleMuxWaitTimeout(boost::system::error_code errorCode)
+{
+    if (errorCode == boost::system::errc::success) {
+        if (mMuxStateMachine.getWaitStateCause() == mux_state::WaitState::WaitStateCause::SwssUpdate) {
+            MUXLOGTIMEOUT(mMuxPortConfig.getPortName(), "orchagent timed out responding to linkmgrd", mCompositeState);
+        } else if (mMuxStateMachine.getWaitStateCause() == mux_state::WaitState::WaitStateCause::DriverUpdate) {
+            MUXLOGTIMEOUT(mMuxPortConfig.getPortName(), "xcvrd timed out responding to linkmgrd", mCompositeState);
+        }
+    } else {
+        MUXLOGTIMEOUT(mMuxPortConfig.getPortName(), "Unknown timeout reason!!!", mCompositeState);
+    }
+    startMuxWaitTimer(MAX_BACKOFF_FACTOR);
+}
+
+//
+// ---> startPeerMuxWaitTimer(uint32_t factor);
+//
+// start a timer to wait for peer mux state notification from xcvrd/orchagent
+//
+void ActiveActiveStateMachine::startPeerMuxWaitTimer(uint32_t factor)
+{
+    mPeerWaitTimer.expires_from_now(boost::posix_time::milliseconds(
+        factor * mMuxPortConfig.getNegativeStateChangeRetryCount() * mMuxPortConfig.getTimeoutIpv4_msec()
+    ));
+    mPeerWaitTimer.async_wait(getStrand().wrap(boost::bind(
+        &ActiveActiveStateMachine::handleMuxWaitTimeout,
+        this,
+        boost::asio::placeholders::error
+    )));
+}
+
+//
+// ---> handlePeerMuxWaitTimeout(boost::system::error_code errorCode);
+//
+// handle when xcrvrd/orchagent has timed out responding peer mux state
+//
+void ActiveActiveStateMachine::handlePeerMuxWaitTimeout(boost::system::error_code errorCode)
+{
+    if (errorCode == boost::system::errc::success) {
+        MUXLOGWARNING(
+            boost::format("%s: %s, current peer mux state: %s") %
+            mMuxPortConfig.getPortName() %
+            "xcvrd timed out responding to linkmgrd peer mux state" %
+            mMuxStateName[mPeerMuxState]
+        );
+    } else {
+        MUXLOGWARNING(
+            boost::format("%s: %s, current peer mux state: %s") %
+            mMuxPortConfig.getPortName() %
+            "Unknown timeout reason!!!" %
+            mMuxStateName[mPeerMuxState]
+        );
+    }
+    startPeerMuxWaitTimer(MAX_BACKOFF_FACTOR);
+}
+
+} /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -64,7 +64,6 @@ ActiveActiveStateMachine::ActiveActiveStateMachine(
 void ActiveActiveStateMachine::activateStateMachine()
 {
     if (mComponentInitState.all()) {
-        // TODO: use known mac address
         std::array<uint8_t, ETHER_ADDR_LEN> macAddress = mMuxPortConfig.getBladeMacAddress();
         std::array<char, 3 *ETHER_ADDR_LEN> macAddressStr = {0};
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -749,16 +749,16 @@ void ActiveActiveStateMachine::initPeerLinkProberState()
 {
     switch (mPeerMuxState) {
         case mux_state::MuxState::Label::Active:
-            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::PeerActive);
+            enterPeerLinkProberState(link_prober::LinkProberState::Label::PeerActive);
             break;
         case mux_state::MuxState::Label::Standby:
-            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::PeerUnknown);
+            enterPeerLinkProberState(link_prober::LinkProberState::Label::PeerUnknown);
             break;
         case mux_state::MuxState::Label::Unknown:
-            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            enterPeerLinkProberState(link_prober::LinkProberState::Label::Wait);
             break;
         case mux_state::MuxState::Label::Error:
-            enterPeerLinkProberState(compositeState, link_prober::LinkProberState::Label::Wait);
+            enterPeerLinkProberState(link_prober::LinkProberState::Label::Wait);
             break;
         default:
             break;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -118,6 +118,9 @@ void ActiveActiveStateMachine::handleSwssSoCIpv4AddressUpdate(boost::asio::ip::a
             mStartProbingFnPtr = boost::bind(
                 &link_prober::LinkProber::startProbing, mLinkProberPtr.get()
             );
+            mUpdateEthernetFrameFnPtr = boost::bind(
+                &link_prober::LinkProber::updateEthernetFrame, mLinkProberPtr.get()
+            );
             mProbePeerTorFnPtr = boost::bind(
                 &link_prober::LinkProber::probePeerTor, mLinkProberPtr.get()
             );

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -394,7 +394,7 @@ void ActiveActiveStateMachine::handlePeerStateChange(
 )
 {
     link_prober::LinkProberState *currentPeerState = std::dynamic_pointer_cast<link_prober::LinkProberStateMachineActiveActive>(mLinkProberStateMachinePtr)->getCurrentPeerState();
-    if (currentPeerState->getStateLabel() == state) {
+    if ((dynamic_cast<link_state::LinkState *>(mLinkProberStateMachinePtr->getCurrentPeerState()))->getStateLabel() == state) {
         MUXLOGWARNING(
             boost::format("%s: Received peer link prober event, new state: %s") %
             mMuxPortConfig.getPortName() %
@@ -677,6 +677,7 @@ void ActiveActiveStateMachine::enterPeerMuxState(mux_state::MuxState::Label labe
 //
 void ActiveActiveStateMachine::enterPeerLinkProberState(link_prober::LinkProberState::Label label)
 {
+    mLinkProberStateMachinePtr->enterPeerState(label);
     mPeerLinkProberState = label;
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -250,6 +250,24 @@ public: // state transition functions
      */
     void LinkProberActiveMuxErrorLinkUpTransitionFunction(CompositeState &nextState);
 
+    /**
+     * @method LinkProberActiveMuxWaitLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberActive, MuxWait, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberActiveMuxWaitLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberUnknownMuxWaitLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberUnknown, MuxWait, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberUnknownMuxWaitLinkUpTransitionFunction(CompositeState &nextState);
+
 private: // utility methods to check/modify state
     /**
      * @method setLabel
@@ -395,10 +413,6 @@ private:
      */
     void handlePeerMuxWaitTimeout(boost::system::error_code errorCode);
 
-private: // peer link prober state and mux state
-    link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerUnknown;
-    mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Unknown;
-
 private: // testing only
     friend class mux::MuxPort;
     friend class test::FakeMuxPort;
@@ -479,6 +493,10 @@ private: // testing only
      * @return none
      */
     void setRestartTxFnPtr(boost::function<void()> restartTxFnPtr) { mRestartTxFnPtr = restartTxFnPtr; }
+
+private: // peer link prober state and mux state
+    link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
+    mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
 
 private:
     boost::asio::deadline_timer mWaitTimer;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -67,9 +67,9 @@ public:
      *
      * @brief Construct a new Active Active State Machine object
      *
-     * @param muxPortPtr            pointer to a MuxPort object
-     * @param strand                boost strand object
-     * @param muxPortConfig         reference to MuxPortConfig object
+     * @param muxPortPtr                    pointer to a MuxPort object
+     * @param strand                        boost strand object
+     * @param muxPortConfig                 reference to MuxPortConfig object
      */
     ActiveActiveStateMachine(
         mux::MuxPort *muxPortPtr,
@@ -99,7 +99,7 @@ public: // db event handlers
      * @brief initialize the link prober component. Note if this is the last component to be initialized,
      *        state machine will be activated
      *
-     * @param address               SoC IPv4 address
+     * @param address                       SoC IPv4 address
      */
     void handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address) override;
 
@@ -108,7 +108,7 @@ public: // db event handlers
      *
      * @brief handle MUX state notification
      *
-     * @param label                 new MuxState label
+     * @param label                         new MuxState label
      */
     void handleMuxStateNotification(mux_state::MuxState::Label label) override;
 
@@ -117,7 +117,7 @@ public: // db event handlers
      *
      * @brief handle link state notification
      *
-     * @param label                 new LinkState label
+     * @param label                         new LinkState label
      */
     void handleSwssLinkStateNotification(const link_state::LinkState::Label label) override;
 
@@ -126,7 +126,7 @@ public: // db event handlers
      *
      * @brief handle MUX configuration change notification
      *
-     * @param mode                  new MUX config mode
+     * @param mode                          new MUX config mode
      */
     void handleMuxConfigNotification(const common::MuxPortConfig::Mode mode) override;
 
@@ -135,7 +135,7 @@ public: // db event handlers
      *
      * @brief handle probe MUX state notification
      *
-     * @param label                 new MuxState label
+     * @param label                         new MuxState label
      */
     void handleProbeMuxStateNotification(mux_state::MuxState::Label label) override;
 
@@ -144,7 +144,7 @@ public: // db event handlers
      *
      * @brief handle peer MUX state notification
      *
-     * @param label                 new peer MuxState label
+     * @param label                         new peer MuxState label
      */
     void handlePeerMuxStateNotification(mux_state::MuxState::Label label) override;
 
@@ -162,8 +162,8 @@ public: // state handlers
      *
      * @brief handles LinkProberEvent
      *
-     * @param event                 LinkProberEvent object
-     * @param state                 new LibProberState label
+     * @param event                         LinkProberEvent object
+     * @param state                         new LibProberState label
      */
     void handleStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state) override;
 
@@ -172,8 +172,8 @@ public: // state handlers
      *
      * @brief handles MuxStateEvent
      *
-     * @param event                 MuxStateEvent object
-     * @param state                 new MuxState label
+     * @param event                         MuxStateEvent object
+     * @param state                         new MuxState label
      */
     void handleStateChange(MuxStateEvent &event, mux_state::MuxState::Label state) override;
 
@@ -182,8 +182,8 @@ public: // state handlers
      *
      * @brief handles LinkStateEvent
      *
-     * @param event                 LinkStateEvent object
-     * @param state                 new LinkState label
+     * @param event                         LinkStateEvent object
+     * @param state                         new LinkState label
      */
     void handleStateChange(LinkStateEvent &event, link_state::LinkState::Label state) override;
 
@@ -192,8 +192,8 @@ public: // state handlers
      *
      * @brief handles peer LinkProberEvent
      *
-     * @param event                 LinkProberEvent object
-     * @param state                 new peer LinkState label
+     * @param event                         LinkProberEvent object
+     * @param state                         new peer LinkState label
      */
     void handlePeerStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state) override;
 
@@ -210,7 +210,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberActive, MuxStandby, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberActiveMuxStandbyLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -219,7 +219,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberActive, MuxUnknown, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberActiveMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -228,7 +228,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberUnknown, MuxActive, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -237,7 +237,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberUnknown, MuxUnknown, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberUnknownMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -246,7 +246,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberActive, MuxError, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberActiveMuxErrorLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -255,7 +255,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberActive, MuxWait, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberActiveMuxWaitLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -264,7 +264,7 @@ public: // state transition functions
      *
      * @brief transition function when entering {LinkProberUnknown, MuxWait, LinkUp} state
      *
-     * @param nextState             reference to composite state
+     * @param nextState                     reference to composite state
      */
     void LinkProberUnknownMuxWaitLinkUpTransitionFunction(CompositeState &nextState);
 
@@ -274,7 +274,7 @@ private: // utility methods to check/modify state
      *
      * @brief sets linkmgr State db state
      *
-     * @param label                 new LinkManagerStateMachine label
+     * @param label                         new LinkManagerStateMachine label
      */
     inline void setLabel(Label label) override;
 
@@ -283,8 +283,8 @@ private: // utility methods to check/modify state
      *
      * @brief force LinkProberState to switch state
      *
-     * @param nextState             reference to composite state
-     * @param label                 new LinkProberState label to switch to
+     * @param nextState                     reference to composite state
+     * @param label                         new LinkProberState label to switch to
      */
     inline void enterLinkProberState(CompositeState &nextState, link_prober::LinkProberState::Label label);
 
@@ -293,8 +293,8 @@ private: // utility methods to check/modify state
      *
      * @brief force MuxState to switch state
      *
-     * @param nextState             reference to composite state
-     * @param label                 new MuxState label to switch to
+     * @param nextState                     reference to composite state
+     * @param label                         new MuxState label to switch to
      */
     inline void enterMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
 
@@ -303,8 +303,8 @@ private: // utility methods to check/modify state
      *
      * @brief force LinkState to switch state
      *
-     * @param nextState             reference to composite state
-     * @param label                 new LinkState label to switch to
+     * @param nextState                     reference to composite state
+     * @param label                         new LinkState label to switch to
      */
     inline void enterLinkState(CompositeState &nextState, link_state::LinkState::Label label);
 
@@ -313,8 +313,8 @@ private: // utility methods to check/modify state
      *
      * @brief force peer MuxState to switch state
      *
-     * @param nextState             reference to composite state
-     * @param label                 new peer MuxState label to switch to
+     * @param nextState                     reference to composite state
+     * @param label                         new peer MuxState label to switch to
      */
     inline void enterPeerMuxState(mux_state::MuxState::Label label);
 
@@ -323,7 +323,7 @@ private: // utility methods to check/modify state
      *
      * @brief force peer LinkProberState to switch state
      *
-     * @param label                 new peer LinkProberState to switch to
+     * @param label                         new peer LinkProberState to switch to
      */
     inline void enterPeerLinkProberState(link_prober::LinkProberState::Label label);
 
@@ -332,8 +332,8 @@ private: // utility methods to check/modify state
      *
      * @brief switch MUX to the target state
      *
-     * @param nextState             reference to composite state
-     * @param label                 new MuxState label to switch to
+     * @param nextState                     reference to composite state
+     * @param label                         new MuxState label to switch to
      */
     inline void switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
 
@@ -342,7 +342,7 @@ private: // utility methods to check/modify state
      *
      * @brief switch peer MUX to the target state
      *
-     * @param label                 new MuxState label to switch to
+     * @param label                         new MuxState label to switch to
      */
     inline void switchPeerMuxState(mux_state::MuxState::Label label);
 
@@ -365,7 +365,7 @@ private: // utility methods to check/modify state
      *
      * @brief initialize LinkProberState when configuring the composite state machine
      *
-     * @param compositeState        reference to composite state
+     * @param compositeState                reference to composite state
      */
     void initLinkProberState(CompositeState &compositeState);
 
@@ -382,7 +382,7 @@ private:
      *
      * @brief start a timer to wait for mux state notification from xcvrd/orchagent
      *
-     * @param factor                factor used to scale the timeout
+     * @param factor                        factor used to scale the timeout
      */
     inline void startMuxWaitTimer(uint32_t factor = 1);
 
@@ -391,7 +391,7 @@ private:
      *
      * @brief handle when xcrvrd/orchagent has timed out responding mux state
      *
-     * @param errorCode             error code object
+     * @param errorCode                     error code object
      */
     void handleMuxWaitTimeout(boost::system::error_code errorCode);
 
@@ -400,7 +400,7 @@ private:
      *
      * @brief start a timer to wait for peer mux state notification from xcvrd/orchagent
      *
-     * @param factor                factor used to scale the timeout
+     * @param factor                        factor used to scale the timeout
      */
     inline void startPeerMuxWaitTimer(uint32_t factor = 1);
 
@@ -409,7 +409,7 @@ private:
      *
      * @brief handle when xcrvrd/orchagent has timed out responding peer mux state
      *
-     * @param errorCode             error code object
+     * @param errorCode                     error code object
      */
     void handlePeerMuxWaitTimeout(boost::system::error_code errorCode);
 
@@ -423,7 +423,7 @@ private: // testing only
      *
      * @brief set new InitializeProberFnPtr for the state machine. This method is used for testing
      *
-     * @param initializeProberFnPtr (in)  pointer to new InitializeProberFnPtr
+     * @param initializeProberFnPtr (in)    pointer to new InitializeProberFnPtr
      */
     void setInitializeProberFnPtr(boost::function<void()> initializeProberFnPtr) { mInitializeProberFnPtr = initializeProberFnPtr; };
 
@@ -432,7 +432,7 @@ private: // testing only
      *
      * @brief set new StartProbingFnPtr for the state machine. This method is used for testing
      *
-     * @param startProbingFnPtr (in)  pointer to new StartProbingFnPtr
+     * @param startProbingFnPtr (in)        pointer to new StartProbingFnPtr
      */
     void setStartProbingFnPtr(boost::function<void()> startProbingFnPtr) { mStartProbingFnPtr = startProbingFnPtr; };
 
@@ -441,7 +441,7 @@ private: // testing only
      *
      * @brief set new UpdateEthernetFrameFnPtr for the state machine. This method is used for testing
      *
-     * @param updateEthernetFrameFnPtr (in)  pointer to new UpdateEthernetFrameFnPtr
+     * @param updateEthernetFrameFnPtr (in) pointer to new UpdateEthernetFrameFnPtr
      */
     void setUpdateEthernetFrameFnPtr(boost::function<void()> updateEthernetFrameFnPtr) { mUpdateEthernetFrameFnPtr = updateEthernetFrameFnPtr; };
 
@@ -450,7 +450,7 @@ private: // testing only
      *
      * @brief set new ProbePeerTorFnPtr for the state machine. This method is used for testing
      *
-     * @param probePeerTorFnPtr (in)  pointer to new ProbePeerTorFnPtr
+     * @param probePeerTorFnPtr (in)        pointer to new ProbePeerTorFnPtr
      */
     void setProbePeerTorFnPtr(boost::function<void()> probePeerTorFnPtr) { mProbePeerTorFnPtr = probePeerTorFnPtr; };
 
@@ -459,7 +459,7 @@ private: // testing only
      *
      * @brief set new SuspendTXFnPtr for the state machine. This method is used for testing
      *
-     * @param suspendTxFnPtr (in)  pointer to new  SuspendTxFnPtr
+     * @param suspendTxFnPtr (in)           pointer to new  SuspendTxFnPtr
      */
     void setSuspendTxFnPtr(boost::function<void(uint32_t suspendTime_msec)> suspendTxFnPtr) { mSuspendTxFnPtr = suspendTxFnPtr; };
 
@@ -468,7 +468,7 @@ private: // testing only
      *
      * @brief set new ResumeTXFnPtr for the state machine. This method is used for testing
      *
-     * @param resumeTxFnPtr (in)  pointer to new  ResumeTxFnPtr
+     * @param resumeTxFnPtr (in)            pointer to new  ResumeTxFnPtr
      */
     void setResumeTxFnPtr(boost::function<void()> resumeTxFnPtr) { mResumeTxFnPtr = resumeTxFnPtr; };
 
@@ -477,7 +477,7 @@ private: // testing only
      *
      * @brief set shutdownTxFnPtr. This method is used for testing
      *
-     * @param shutdownTxFnPtr (in) pointer to new ShutdownTxFnPtr
+     * @param shutdownTxFnPtr (in)          pointer to new ShutdownTxFnPtr
      *
      * @return none
      */
@@ -488,7 +488,7 @@ private: // testing only
      *
      * @brief set restartTxFnPtr. This method is used for testing
      *
-     * @param restartTxFnPtr (in) pointer to new restartTxFnPtr
+     * @param restartTxFnPtr (in)           pointer to new restartTxFnPtr
      *
      * @return none
      */

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -378,6 +378,18 @@ private: // utility methods to check/modify state
 
 private:
     /**
+     * @brief start a mux probe and wait for mux probe notification(active or standby) from xcvrd
+     */
+    inline void startMuxProbeTimer();
+
+    /**
+     * @brief handles when xcvrd has timeout responding mux probe
+     *
+     * @param errorCode                     error code object
+     */
+    void handleMuxProbeTimeout(boost::system::error_code errorCode);
+
+    /**
      * @method startMuxWaitTimer
      *
      * @brief start a timer to wait for mux state notification from xcvrd/orchagent
@@ -499,6 +511,9 @@ private: // peer link prober state and mux state
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
 
 private:
+    uint32_t mMuxProbeBackoffFactor = 1;
+
+    boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -399,6 +399,11 @@ private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerUnknown;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Unknown;
 
+private: // testing only
+    friend class mux::MuxPort;
+    friend class test::FakeMuxPort;
+    friend class test::MuxManagerTest;
+
 private:
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -404,6 +404,82 @@ private: // testing only
     friend class test::FakeMuxPort;
     friend class test::MuxManagerTest;
 
+    /**
+     * @method setInitializeProberFnPtr
+     *
+     * @brief set new InitializeProberFnPtr for the state machine. This method is used for testing
+     *
+     * @param initializeProberFnPtr (in)  pointer to new InitializeProberFnPtr
+     */
+    void setInitializeProberFnPtr(boost::function<void()> initializeProberFnPtr) { mInitializeProberFnPtr = initializeProberFnPtr; };
+
+    /**
+     * @method setStartProbingFnPtr
+     *
+     * @brief set new StartProbingFnPtr for the state machine. This method is used for testing
+     *
+     * @param startProbingFnPtr (in)  pointer to new StartProbingFnPtr
+     */
+    void setStartProbingFnPtr(boost::function<void()> startProbingFnPtr) { mStartProbingFnPtr = startProbingFnPtr; };
+
+    /**
+     * @method setUpdateEthernetFrameFnPtr
+     *
+     * @brief set new UpdateEthernetFrameFnPtr for the state machine. This method is used for testing
+     *
+     * @param updateEthernetFrameFnPtr (in)  pointer to new UpdateEthernetFrameFnPtr
+     */
+    void setUpdateEthernetFrameFnPtr(boost::function<void()> updateEthernetFrameFnPtr) { mUpdateEthernetFrameFnPtr = updateEthernetFrameFnPtr; };
+
+    /**
+     * @method setProbePeerTorFnPtr
+     *
+     * @brief set new ProbePeerTorFnPtr for the state machine. This method is used for testing
+     *
+     * @param probePeerTorFnPtr (in)  pointer to new ProbePeerTorFnPtr
+     */
+    void setProbePeerTorFnPtr(boost::function<void()> probePeerTorFnPtr) { mProbePeerTorFnPtr = probePeerTorFnPtr; };
+
+    /**
+     * @method setSuspendTxFnPtr
+     *
+     * @brief set new SuspendTXFnPtr for the state machine. This method is used for testing
+     *
+     * @param suspendTxFnPtr (in)  pointer to new  SuspendTxFnPtr
+     */
+    void setSuspendTxFnPtr(boost::function<void(uint32_t suspendTime_msec)> suspendTxFnPtr) { mSuspendTxFnPtr = suspendTxFnPtr; };
+
+    /**
+     * @method setResumeTxFnPtr
+     *
+     * @brief set new ResumeTXFnPtr for the state machine. This method is used for testing
+     *
+     * @param resumeTxFnPtr (in)  pointer to new  ResumeTxFnPtr
+     */
+    void setResumeTxFnPtr(boost::function<void()> resumeTxFnPtr) { mResumeTxFnPtr = resumeTxFnPtr; };
+
+    /**
+     * @method setShutdownTxFnPtr
+     *
+     * @brief set shutdownTxFnPtr. This method is used for testing
+     *
+     * @param shutdownTxFnPtr (in) pointer to new ShutdownTxFnPtr
+     *
+     * @return none
+     */
+    void setShutdownTxFnPtr(boost::function<void()> shutdownTxFnPtr) { mShutdownTxFnPtr = shutdownTxFnPtr; }
+
+    /**
+     * @method setRestartTxFnPtr
+     *
+     * @brief set restartTxFnPtr. This method is used for testing
+     *
+     * @param restartTxFnPtr (in) pointer to new restartTxFnPtr
+     *
+     * @return none
+     */
+    void setRestartTxFnPtr(boost::function<void()> restartTxFnPtr) { mRestartTxFnPtr = restartTxFnPtr; }
+
 private:
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -1,0 +1,418 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINK_MANAGER_LINKMANAGERSTATEMACHINEACTIVEACTIVE_H_
+#define LINK_MANAGER_LINKMANAGERSTATEMACHINEACTIVEACTIVE_H_
+
+#include <bitset>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <vector>
+#include <boost/function.hpp>
+
+#include "link_manager/LinkManagerStateMachineBase.h"
+#include "link_prober/LinkProber.h"
+#include "link_prober/LinkProberState.h"
+#include "link_state/LinkState.h"
+#include "link_state/LinkStateMachine.h"
+#include "mux_state/MuxState.h"
+#include "mux_state/MuxStateMachine.h"
+
+namespace mux
+{
+#define ps(compositeState) std::get<0>(compositeState)
+#define ms(compositeState) std::get<1>(compositeState)
+#define ls(compositeState) std::get<2>(compositeState)
+
+class MuxPort;
+} // namespace mux
+
+namespace link_manager
+{
+
+class ActiveActiveStateMachine : public LinkManagerStateMachineBase,
+                                 public std::enable_shared_from_this<ActiveActiveStateMachine>
+{
+public:
+    /**
+     * @method ActiveActiveStateMachine
+     *
+     * @brief Construct a new Active Active State Machine object
+     */
+    ActiveActiveStateMachine() = delete;
+
+    /**
+     * @method ActiveActiveStateMachine
+     *
+     * @brief Construct a new Active Active State Machine object
+     */
+    ActiveActiveStateMachine(const ActiveActiveStateMachine &) = delete;
+
+    /**
+     * @method ActiveActiveStateMachine
+     *
+     * @brief Construct a new Active Active State Machine object
+     *
+     * @param muxPortPtr            pointer to a MuxPort object
+     * @param strand                boost strand object
+     * @param muxPortConfig         reference to MuxPortConfig object
+     */
+    ActiveActiveStateMachine(
+        mux::MuxPort *muxPortPtr,
+        boost::asio::io_service::strand &strand,
+        common::MuxPortConfig &muxPortConfig
+    );
+
+    /**
+     * @method ~ActiveActiveStateMachine
+     *
+     * @brief Destroy the Active Active State Machine object
+     */
+    virtual ~ActiveActiveStateMachine() = default;
+
+public:
+    /**
+     * @method activateStateMachine
+     *
+     * @brief activate the state machine by starting the link prober.
+     */
+    void activateStateMachine();
+
+public: // db event handlers
+    /**
+     * @method handleSwssSoCIpv4AddressUpdate
+     *
+     * @brief initialize the link prober component. Note if this is the last component to be initialized,
+     *        state machine will be activated
+     *
+     * @param address               SoC IPv4 address
+     */
+    void handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address) override;
+
+    /**
+     * @method handleMuxStateNotification
+     *
+     * @brief handle MUX state notification
+     *
+     * @param label                 new MuxState label
+     */
+    void handleMuxStateNotification(mux_state::MuxState::Label label) override;
+
+    /**
+     * @method handleSwssLinkStateNotification
+     *
+     * @brief handle link state notification
+     *
+     * @param label                 new LinkState label
+     */
+    void handleSwssLinkStateNotification(const link_state::LinkState::Label label) override;
+
+    /**
+     * @method handleMuxConfigNotification
+     *
+     * @brief handle MUX configuration change notification
+     *
+     * @param mode                  new MUX config mode
+     */
+    void handleMuxConfigNotification(const common::MuxPortConfig::Mode mode) override;
+
+    /**
+     * @method handleProbeMuxStateNotification
+     *
+     * @brief handle probe MUX state notification
+     *
+     * @param label                 new MuxState label
+     */
+    void handleProbeMuxStateNotification(mux_state::MuxState::Label label) override;
+
+    /**
+     * @method handlePeerMuxStateNotification
+     *
+     * @brief handle peer MUX state notification
+     *
+     * @param label                 new peer MuxState label
+     */
+    void handlePeerMuxStateNotification(mux_state::MuxState::Label label) override;
+
+public: // link prober event handlers
+    /**
+     * @method handleSuspendTimerExpiry
+     *
+     * @brief handle completion of sending switch command to peer ToR
+     */
+    void handleSuspendTimerExpiry() override;
+
+public: // state handlers
+    /**
+     * @method handleStateChange
+     *
+     * @brief handles LinkProberEvent
+     *
+     * @param event                 LinkProberEvent object
+     * @param state                 new LibProberState label
+     */
+    void handleStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state) override;
+
+    /**
+     * @method handleStateChange
+     *
+     * @brief handles MuxStateEvent
+     *
+     * @param event                 MuxStateEvent object
+     * @param state                 new MuxState label
+     */
+    void handleStateChange(MuxStateEvent &event, mux_state::MuxState::Label state) override;
+
+    /**
+     * @method handleStateChange
+     *
+     * @brief handles LinkStateEvent
+     *
+     * @param event                 LinkStateEvent object
+     * @param state                 new LinkState label
+     */
+    void handleStateChange(LinkStateEvent &event, link_state::LinkState::Label state) override;
+
+    /**
+     * @method handlePeerStateChange
+     *
+     * @brief handles peer LinkProberEvent
+     *
+     * @param event                 LinkProberEvent object
+     * @param state                 new peer LinkState label
+     */
+    void handlePeerStateChange(LinkProberEvent &event, link_prober::LinkProberState::Label state) override;
+
+public: // state transition functions
+    /**
+     * @method initializeTransitionFunctionTable
+     *
+     * @brief initialize static transition function table
+     */
+    void initializeTransitionFunctionTable() override;
+
+    /**
+     * @method LinkProberActiveMuxStandbyLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberActive, MuxStandby, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberActiveMuxStandbyLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberActiveMuxUnknownLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberActive, MuxUnknown, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberActiveMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberUnknownMuxActiveLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberUnknown, MuxActive, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberUnknownMuxUnknownLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberUnknown, MuxUnknown, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberUnknownMuxUnknownLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberActiveMuxErrorLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberActive, MuxError, LinkUp} state
+     *
+     * @param nextState             reference to composite state
+     */
+    void LinkProberActiveMuxErrorLinkUpTransitionFunction(CompositeState &nextState);
+
+private: // utility methods to check/modify state
+    /**
+     * @method setLabel
+     *
+     * @brief sets linkmgr State db state
+     *
+     * @param label                 new LinkManagerStateMachine label
+     */
+    inline void setLabel(Label label) override;
+
+    /**
+     * @method enterLinkProberState
+     *
+     * @brief force LinkProberState to switch state
+     *
+     * @param nextState             reference to composite state
+     * @param label                 new LinkProberState label to switch to
+     */
+    inline void enterLinkProberState(CompositeState &nextState, link_prober::LinkProberState::Label label);
+
+    /**
+     * @method enterMuxState
+     *
+     * @brief force MuxState to switch state
+     *
+     * @param nextState             reference to composite state
+     * @param label                 new MuxState label to switch to
+     */
+    inline void enterMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
+
+    /**
+     * @method enterLinkState
+     *
+     * @brief force LinkState to switch state
+     *
+     * @param nextState             reference to composite state
+     * @param label                 new LinkState label to switch to
+     */
+    inline void enterLinkState(CompositeState &nextState, link_state::LinkState::Label label);
+
+    /**
+     * @method enterPeerMuxState
+     *
+     * @brief force peer MuxState to switch state
+     *
+     * @param nextState             reference to composite state
+     * @param label                 new peer MuxState label to switch to
+     */
+    inline void enterPeerMuxState(mux_state::MuxState::Label label);
+
+    /**
+     * @method enterPeerLinkProberState
+     *
+     * @brief force peer LinkProberState to switch state
+     *
+     * @param label                 new peer LinkProberState to switch to
+     */
+    inline void enterPeerLinkProberState(link_prober::LinkProberState::Label label);
+
+    /**
+     * @method switchMuxState
+     *
+     * @brief switch MUX to the target state
+     *
+     * @param nextState             reference to composite state
+     * @param label                 new MuxState label to switch to
+     */
+    inline void switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
+
+    /**
+     * @method switchPeerMuxState
+     *
+     * @brief switch peer MUX to the target state
+     *
+     * @param label                 new MuxState label to switch to
+     */
+    inline void switchPeerMuxState(mux_state::MuxState::Label label);
+
+    /**
+     * @method probeMuxState
+     *
+     * @brief probe mux state
+     */
+    inline void probeMuxState();
+
+    /**
+     * @method updateMuxLinkmgrState
+     *
+     * @brief update State DB MUX LinkMgr state
+     */
+    void updateMuxLinkmgrState();
+
+    /**
+     * @method initLinkProberState
+     *
+     * @brief initialize LinkProberState when configuring the composite state machine
+     *
+     * @param compositeState        reference to composite state
+     */
+    void initLinkProberState(CompositeState &compositeState);
+
+    /**
+     * @method initPeerLinkProberState
+     *
+     * @brief initialize peer LinkProberState when configuring the composite state machine
+     */
+    void initPeerLinkProberState();
+
+private:
+    /**
+     * @method startMuxWaitTimer
+     *
+     * @brief start a timer to wait for mux state notification from xcvrd/orchagent
+     *
+     * @param factor                factor used to scale the timeout
+     */
+    inline void startMuxWaitTimer(uint32_t factor = 1);
+
+    /**
+     * @method handleMuxWaitTimeout
+     *
+     * @brief handle when xcrvrd/orchagent has timed out responding mux state
+     *
+     * @param errorCode             error code object
+     */
+    void handleMuxWaitTimeout(boost::system::error_code errorCode);
+
+    /**
+     * @method startPeerMuxWaitTimer
+     *
+     * @brief start a timer to wait for peer mux state notification from xcvrd/orchagent
+     *
+     * @param factor                factor used to scale the timeout
+     */
+    inline void startPeerMuxWaitTimer(uint32_t factor = 1);
+
+    /**
+     * @method handlePeerMuxWaitTimeout
+     *
+     * @brief handle when xcrvrd/orchagent has timed out responding peer mux state
+     *
+     * @param errorCode             error code object
+     */
+    void handlePeerMuxWaitTimeout(boost::system::error_code errorCode);
+
+private: // peer link prober state and mux state
+    link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerUnknown;
+    mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Unknown;
+
+private:
+    boost::asio::deadline_timer mWaitTimer;
+    boost::asio::deadline_timer mPeerWaitTimer;
+
+    boost::function<void()> mInitializeProberFnPtr;
+    boost::function<void()> mStartProbingFnPtr;
+    boost::function<void()> mUpdateEthernetFrameFnPtr;
+    boost::function<void()> mProbePeerTorFnPtr;
+    boost::function<void(uint32_t suspendTime_msec)> mSuspendTxFnPtr;
+    boost::function<void()> mResumeTxFnPtr;
+    boost::function<void()> mShutdownTxFnPtr;
+    boost::function<void()> mRestartTxFnPtr;
+};
+
+} /* namespace link_manager */
+
+#endif /* LINK_MANAGER_LINKMANAGERSTATEMACHINEACTIVEACTIVE_H_ */

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -28,36 +28,6 @@
 #include "common/MuxException.h"
 #include "MuxPort.h"
 
-#define LOG_MUX_STATE_TRANSITION(level, portName, currentState, nextState) \
-    do { \
-        MUXLOG##level(boost::format("%s: (P: %s, M: %s, L: %s) -> (P: %s, M: %s, L: %s)") % \
-            portName % \
-            mLinkProberStateName[ps(currentState)] % \
-            mMuxStateName[ms(currentState)] % \
-            mLinkStateName[ls(currentState)] % \
-            mLinkProberStateName[ps(nextState)] % \
-            mMuxStateName[ms(nextState)] % \
-            mLinkStateName[ls(nextState)] \
-        ); \
-    } while (0)
-
-#define LOGWARNING_MUX_STATE_TRANSITION(portName, currentState, nextState) \
-    LOG_MUX_STATE_TRANSITION(WARNING, portName, currentState, nextState)
-
-#define LOGINFO_MUX_STATE_TRANSITION(portName, currentState, nextState) \
-    LOG_MUX_STATE_TRANSITION(INFO, portName, currentState, nextState)
-
-#define MUXLOGTIMEOUT(portname, msg, currentState) \
-    do { \
-        MUXLOGWARNING(boost::format("%s: %s, current state: (P: %s, M: %s, L: %s)") % \
-            portname % \
-            msg % \
-            mLinkProberStateName[ps(currentState)] % \
-            mMuxStateName[ms(currentState)] % \
-            mLinkStateName[ls(currentState)] \
-        ); \
-    } while (0)
-
 namespace link_manager
 {
 
@@ -1073,16 +1043,6 @@ void ActiveStandbyStateMachine::postMuxStateEvent(mux_state::MuxState::Label lab
     default:
         break;
     }
-}
-
-//
-// ---> noopTransitionFunction(CompositeState &nextState);
-//
-// No-op transition function
-//
-void ActiveStandbyStateMachine::noopTransitionFunction(CompositeState &nextState)
-{
-    MUXLOGINFO(mMuxPortConfig.getPortName());
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1021,31 +1021,6 @@ void ActiveStandbyStateMachine::initLinkProberState(CompositeState &compositeSta
 }
 
 //
-// ---> postMuxStateEvent(mux_state::MuxState::Label label)
-//
-// post event to MUX state machine to change state
-//
-void ActiveStandbyStateMachine::postMuxStateEvent(mux_state::MuxState::Label label)
-{
-    switch (label) {
-    case mux_state::MuxState::Label::Active:
-        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getActiveEvent());
-        break;
-    case mux_state::MuxState::Label::Standby:
-        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getStandbyEvent());
-        break;
-    case mux_state::MuxState::Label::Unknown:
-        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getUnknownEvent());
-        break;
-    case mux_state::MuxState::Label::Error:
-        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getErrorEvent());
-        break;
-    default:
-        break;
-    }
-}
-
-//
 // ---> LinkProberStandbyMuxActiveLinkUpTransitionFunction(CompositeState &nextState);
 //
 // transition function when entering {LinkProberStandby, MuxActive, LinkUp} state

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -86,20 +86,6 @@ public:
         Count
     };
 
-private:
-    /**
-     *@enum anonymous
-     *
-     *@brief used to reference bits corresponding to respective state machine init state
-     */
-    enum {
-        LinkProberComponent,
-        MuxStateComponent,
-        LinkStateComponent,
-
-        ComponentCount
-    };
-
 public:
     /**
     *@method ActiveStandbyStateMachine
@@ -802,17 +788,6 @@ private:
     };
 
     /**
-    *@method setComponentInitState
-    *
-    *@brief set component inti state. This method is used for testing
-    *
-    *@param component (in)  component index
-    *
-    *@return none
-    */
-    void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
-
-    /**
      * @method setShutdownTxFnPtr
      * 
      * @brief set shutdownTxFnPtr. This method is used for testing
@@ -893,8 +868,6 @@ private:
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
     DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
-
-    std::bitset<ComponentCount> mComponentInitState = {0};
 };
 
 } /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -501,17 +501,6 @@ private:
     void postMuxStateEvent(mux_state::MuxState::Label label);
 
     /**
-    *@method noopTransitionFunction
-    *
-    *@brief No-op transition function
-    *
-    *@param nextState (in, out)     reference to composite
-    *
-    *@return none
-    */
-    void noopTransitionFunction(CompositeState &nextState);
-
-    /**
     *@method LinkProberStandbyMuxActiveLinkUpTransitionFunction
     *
     *@brief transition function when entering {LinkProberStandby, MuxActive, LinkUp} state

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -475,18 +475,6 @@ private:
     void initLinkProberState(CompositeState &compositeState);
 
     /**
-    *@method postMuxStateEvent
-    *
-    *@brief post event to MUX state machine to change state
-    *
-    *@param label (in)      new state label to post event for
-    *
-    *
-    *@return none
-    */
-    void postMuxStateEvent(mux_state::MuxState::Label label);
-
-    /**
     *@method LinkProberStandbyMuxActiveLinkUpTransitionFunction
     *
     *@brief transition function when entering {LinkProberStandby, MuxActive, LinkUp} state

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -183,6 +183,15 @@ void LinkManagerStateMachineBase::handlePeerLinkStateNotification(const link_sta
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }
 
+// ---> handlePeerMuxStateNotification(mux_state::MuxState::Label label);
+//
+// handle peer MUX state change notification
+//
+void LinkManagerStateMachineBase::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
 //
 // ---> handleMuxConfigNotification(const common::MuxPortConfig::Mode mode);
 //

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -114,6 +114,17 @@ void LinkManagerStateMachineBase::handleSwssBladeIpv4AddressUpdate(boost::asio::
 }
 
 //
+// ---> handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address);
+//
+// initialize LinkProber component. Note if this is the last component to be initialized,
+// state machine will be activated
+//
+void LinkManagerStateMachineBase::handleSwssSoCIpv4AddressUpdate(boost::asio::ip::address address)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
 // ---> handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
 //
 // handle get Server MAC address

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -26,7 +26,7 @@ LinkProberEvent LinkManagerStateMachineBase::mLinkProberEvent;
 MuxStateEvent LinkManagerStateMachineBase::mMuxStateEvent;
 LinkStateEvent LinkManagerStateMachineBase::mLinkStateEvent;
 
-std::vector<std::string> LinkManagerStateMachineBase::mLinkProberStateName = {"Active", "Standby", "Unknown", "Wait"};
+std::vector<std::string> LinkManagerStateMachineBase::mLinkProberStateName = {"Active", "Standby", "Unknown", "Wait", "PeerWait", "PeerActive", "PeerUnknown"};
 std::vector<std::string> LinkManagerStateMachineBase::mMuxStateName = {"Active", "Standby", "Unknown", "Error", "Wait"};
 std::vector<std::string> LinkManagerStateMachineBase::mLinkStateName = {"Up", "Down"};
 std::vector<std::string> LinkManagerStateMachineBase::mLinkHealthName = {"Uninitialized", "Unhealthy", "Healthy"};

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -263,13 +263,4 @@ void LinkManagerStateMachineBase::handleResetLinkProberPckLossCount()
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }
 
-// ---> LinkManagerStateMachineBase::setComponentInitState(uint8_t component)
-//
-// set component inti state. This method is used for testing
-//
-void LinkManagerStateMachineBase::setComponentInitState(uint8_t component)
-{
-    MUXLOGINFO(mMuxPortConfig.getPortName());
-};
-
 } /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -56,6 +56,11 @@ LinkManagerStateMachineBase::LinkManagerStateMachineBase(
                 this, strand, mMuxPortConfig, ps(mCompositeState)
             );
             break;
+        case common::MuxPortConfig::PortCableType::ActiveActive:
+            mLinkProberStateMachinePtr = std::make_shared<link_prober::LinkProberStateMachineActiveActive>(
+                this, strand, mMuxPortConfig, ps(mCompositeState)
+            );
+            break;
         default:
             break;
     }

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -263,4 +263,29 @@ void LinkManagerStateMachineBase::handleResetLinkProberPckLossCount()
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }
 
+//
+// ---> postMuxStateEvent(mux_state::MuxState::Label label)
+//
+// post event to MUX state machine to change state
+//
+void LinkManagerStateMachineBase::postMuxStateEvent(mux_state::MuxState::Label label)
+{
+    switch (label) {
+    case mux_state::MuxState::Label::Active:
+        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getActiveEvent());
+        break;
+    case mux_state::MuxState::Label::Standby:
+        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getStandbyEvent());
+        break;
+    case mux_state::MuxState::Label::Unknown:
+        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getUnknownEvent());
+        break;
+    case mux_state::MuxState::Label::Error:
+        mMuxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getErrorEvent());
+        break;
+    default:
+        break;
+    }
+}
+
 } /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -518,6 +518,18 @@ private:
      */
     void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
 
+    /**
+    *@method postMuxStateEvent
+    *
+    *@brief post event to MUX state machine to change state
+    *
+    *@param label (in)      new state label to post event for
+    *
+    *
+    *@return none
+    */
+    void postMuxStateEvent(mux_state::MuxState::Label label);
+
 private:
     static LinkProberEvent mLinkProberEvent;
     static MuxStateEvent mMuxStateEvent;

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -361,6 +361,17 @@ public:
     virtual void handlePeerLinkStateNotification(const link_state::LinkState::Label label);
 
     /**
+     *@method handlePeerMuxStateNotification
+     *
+     *@brief handle peer MUX state notification
+     *
+     *@param label (in)              new peer MuxState label
+     *
+     *@return none
+     */
+    virtual void handlePeerMuxStateNotification(mux_state::MuxState::Label label);
+
+    /**
      *@method handleMuxConfigNotification
      *
      *@brief handle MUX configuration change notification

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -62,6 +62,11 @@
         ); \
     } while (0)
 
+namespace test {
+class FakeMuxPort;
+class MuxManagerTest;
+}
+
 namespace mux {
 #define ps(compositeState) std::get<0>(compositeState)
 #define ms(compositeState) std::get<1>(compositeState)
@@ -434,17 +439,6 @@ public:
      */
     virtual void handleResetLinkProberPckLossCount();
 
-    /**
-     *@method setComponentInitState
-     *
-     *@brief set component inti state. This method is used for testing
-     *
-     *@param component (in)  component index
-     *
-     *@return none
-     */
-    virtual void setComponentInitState(uint8_t component);
-
 public:
     /**
     *@method getLinkProberStateMachinePtr
@@ -474,6 +468,23 @@ public:
     link_state::LinkStateMachine& getLinkStateMachine() {return mLinkStateMachine;};
 
 private:
+    /**
+     *@enum anonymous
+     *
+     *@brief used to reference bits corresponding to respective state machine init state
+     */
+    enum {
+        LinkProberComponent,
+        MuxStateComponent,
+        LinkStateComponent,
+
+        ComponentCount
+    };
+
+private:
+    friend class mux::MuxPort;
+    friend class test::FakeMuxPort;
+    friend class test::MuxManagerTest;
     friend class ActiveStandbyStateMachine;
     friend class ActiveActiveStateMachine;
 
@@ -495,6 +506,17 @@ private:
      * @param nextState reference to CompositeState object
      */
     void noopTransitionFunction(CompositeState& nextState);
+
+    /**
+     *@method setComponentInitState
+     *
+     *@brief set component inti state. This method is used for testing
+     *
+     *@param component (in)  component index
+     *
+     *@return none
+     */
+    void setComponentInitState(uint8_t component) {mComponentInitState.set(component);};
 
 private:
     static LinkProberEvent mLinkProberEvent;
@@ -520,6 +542,8 @@ private:
     link_state::LinkStateMachine mLinkStateMachine;
 
     Label mLabel = Label::Uninitialized;
+
+    std::bitset<ComponentCount> mComponentInitState = {0};
 };
 
 } /* namespace link_manager */

--- a/src/link_manager/subdir.mk
+++ b/src/link_manager/subdir.mk
@@ -2,15 +2,17 @@
 CPP_SRCS += \
 	./src/link_manager/LinkManagerStateMachineBase.cpp \
     ./src/link_manager/LinkManagerStateMachineActiveStandby.cpp \
+    ./src/link_manager/LinkManagerStateMachineActiveActive.cpp \
 
 OBJS += \
 	./src/link_manager/LinkManagerStateMachineBase.o \
     ./src/link_manager/LinkManagerStateMachineActiveStandby.o \
- 
+    ./src/link_manager/LinkManagerStateMachineActiveActive.o \
 
 CPP_DEPS += \
 	./src/link_manager/LinkManagerStateMachineBase.d \
     ./src/link_manager/LinkManagerStateMachineActiveStandby.d \
+    ./src/link_manager/LinkManagerStateMachineActiveActive.d \
 
 # Each subdirectory must supply rules for building sources it contributes
 src/link_manager/%.o: src/link_manager/%.cpp

--- a/src/link_prober/LinkProberState.h
+++ b/src/link_prober/LinkProberState.h
@@ -54,6 +54,7 @@ public:
         Standby,
         Unknown,
         Wait,
+        PeerWait,
         PeerActive,
         PeerUnknown,
         Count

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -149,6 +149,21 @@ void LinkProberStateMachineActiveActive::processEvent(IcmpPeerUnknownEvent &Icmp
 }
 
 //
+// ---> processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent);
+//
+// process LinkProberState suspend timer expiry event
+//
+void LinkProberStateMachineActiveActive::processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent)
+{
+    boost::asio::io_service::strand &strand = mLinkManagerStateMachinePtr->getStrand();
+    boost::asio::io_service &ioService = strand.context();
+    ioService.post(strand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handleSuspendTimerExpiry,
+        mLinkManagerStateMachinePtr
+    )));
+}
+
+//
 // ---> postLinkManagerPeerEvent(LinkProberState* linkProberState);
 //
 // post LinkProberState peer change event to LinkManager state machine

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -60,6 +60,9 @@ void LinkProberStateMachineActiveActive::enterState(LinkProberState::Label label
         case LinkProberState::Label::Unknown:
             setCurrentState(dynamic_cast<LinkProberState *>(getUnknownState()));
             break;
+        case LinkProberState::Label::Wait:
+            setCurrentState(dynamic_cast<LinkProberState *>(getWaitState()));
+            break;
         default:
             break;
     }

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -69,6 +69,16 @@ void LinkProberStateMachineActiveActive::enterState(LinkProberState::Label label
 }
 
 //
+// ---> getCurrentPeerState();
+//
+// getter for current peer state
+//
+LinkProberState *LinkProberStateMachineActiveActive::getCurrentPeerState()
+{
+    return mCurrentPeerState;
+}
+
+//
 // ---> enterPeerState(LinkProberState::Label label);
 //
 // force the state machine to enter a given peer state

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -42,7 +42,7 @@ LinkProberStateMachineActiveActive::LinkProberStateMachineActiveActive(
     : LinkProberStateMachineBase(linkManagerStateMachinePtr, strand, muxPortConfig)
 {
     enterState(label);
-    enterPeerState(LinkProberState::Label::PeerUnknown);
+    enterPeerState(LinkProberState::Label::PeerWait);
 }
 
 //
@@ -82,6 +82,9 @@ void LinkProberStateMachineActiveActive::enterPeerState(LinkProberState::Label l
             break;
         case LinkProberState::Label::PeerUnknown:
             setCurrentPeerState(dynamic_cast<LinkProberState *>(getPeerUnknownState()));
+            break;
+        case LinkProberState::Label::PeerWait:
+            setCurrentPeerState(dynamic_cast<LinkProberState *>(getPeerWaitState()));
             break;
         default:
             break;

--- a/src/link_prober/LinkProberStateMachineActiveActive.h
+++ b/src/link_prober/LinkProberStateMachineActiveActive.h
@@ -107,6 +107,17 @@ public:
      */
     void processEvent(IcmpPeerUnknownEvent &icmpPeerUnknownEvent) override;
 
+    /**
+     *@method processEvent
+     *
+     *@brief process SuspendTimerExpiredEvent
+     *
+     *@param suspendTimerExpiredEvent (in)  reference to the SuspendTimerExpiredEvent event
+     *
+     *@return none
+     */
+    void processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent) override;
+
 private:
     /**
      *@method enterPeerState

--- a/src/link_prober/LinkProberStateMachineActiveActive.h
+++ b/src/link_prober/LinkProberStateMachineActiveActive.h
@@ -118,6 +118,15 @@ public:
      */
     void processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent) override;
 
+    /**
+     *@method getCurrentPeerState
+     *
+     *@brief getter for current peer state
+     *
+     *@return current peer state of the state machine
+     */
+    LinkProberState *getCurrentPeerState() { return mCurrentPeerState; }
+
 private:
     /**
      *@method enterPeerState
@@ -129,15 +138,6 @@ private:
      *@return none
      */
     void enterPeerState(LinkProberState::Label label);
-
-    /**
-     *@method getCurrentPeerState
-     *
-     *@brief getter for current peer state
-     *
-     *@return current peer state of the state machine
-     */
-    LinkProberState *getCurrentPeerState() { return mCurrentPeerState; }
 
     /**
      *@method setCurrentPeerState

--- a/src/link_prober/LinkProberStateMachineActiveActive.h
+++ b/src/link_prober/LinkProberStateMachineActiveActive.h
@@ -125,9 +125,8 @@ public:
      *
      *@return current peer state of the state machine
      */
-    LinkProberState *getCurrentPeerState() { return mCurrentPeerState; }
+    LinkProberState *getCurrentPeerState() override;
 
-private:
     /**
      *@method enterPeerState
      *
@@ -137,8 +136,9 @@ private:
      *
      *@return none
      */
-    void enterPeerState(LinkProberState::Label label);
+    void enterPeerState(LinkProberState::Label label) override;
 
+private:
     /**
      *@method setCurrentPeerState
      *

--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -48,7 +48,8 @@ LinkProberStateMachineBase::LinkProberStateMachineBase(
     mUnknownState(*this, muxPortConfig),
     mWaitState(*this, muxPortConfig),
     mPeerActiveState(*this, muxPortConfig),
-    mPeerUnknownState(*this, muxPortConfig)
+    mPeerUnknownState(*this, muxPortConfig),
+    mPeerWaitState(*this, muxPortConfig)
 {
 }
 

--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -231,6 +231,27 @@ void LinkProberStateMachineBase::handlePckLossRatioUpdate(const uint64_t unknown
 }
 
 //
+// ---> getCurrentPeerState();
+//
+// getter for current peer state
+//
+LinkProberState *LinkProberStateMachineBase::getCurrentPeerState()
+{
+    MUXLOGERROR(mMuxPortConfig.getPortName());
+    return nullptr;
+}
+
+//
+// ---> enterPeerState(LinkProberState::Label label);
+//
+// force the state machine to enter a given peer state
+//
+void LinkProberStateMachineBase::enterPeerState(LinkProberState::Label label)
+{
+    MUXLOGERROR(mMuxPortConfig.getPortName());
+}
+
+//
 // ---> postLinkManagerEvent(LinkProberState* linkProberState);
 //
 // post LinkProberState change event to LinkManager state machine

--- a/src/link_prober/LinkProberStateMachineBase.h
+++ b/src/link_prober/LinkProberStateMachineBase.h
@@ -292,6 +292,27 @@ public:
     virtual void handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount);
 
 public:
+    /**
+     *@method getCurrentPeerState
+     *
+     *@brief getter for current peer state
+     *
+     *@return current peer state of the state machine
+     */
+    virtual LinkProberState *getCurrentPeerState();
+
+    /**
+     *@method enterPeerState
+     *
+     *@brief force the state machine to enter a given peer state
+     *
+     *@param label (in)  label of target peer state
+     *
+     *@return none
+     */
+    virtual void enterPeerState(LinkProberState::Label label);
+
+public:
    /**
     *@method getActiveState
     *

--- a/src/link_prober/LinkProberStateMachineBase.h
+++ b/src/link_prober/LinkProberStateMachineBase.h
@@ -20,6 +20,7 @@
 #include "link_prober/ActiveState.h"
 #include "link_prober/PeerActiveState.h"
 #include "link_prober/PeerUnknownState.h"
+#include "link_prober/PeerWaitState.h"
 #include "link_prober/StandbyState.h"
 #include "link_prober/UnknownState.h"
 #include "link_prober/WaitState.h"
@@ -345,6 +346,15 @@ public:
     */
     PeerUnknownState* getPeerUnknownState() {return &mPeerUnknownState;};
 
+    /**
+    *@method getPeerWaitState
+    *
+    *@brief getter for PeerWaitState object
+    *
+    *@return pointer to PeerWaitState object
+    */
+    PeerWaitState* getPeerWaitState() {return &mPeerWaitState;};
+
 public:
     /**
      *@method getIcmpSelfEvent
@@ -452,6 +462,7 @@ private:
     WaitState mWaitState;
     PeerActiveState mPeerActiveState;
     PeerUnknownState mPeerUnknownState;
+    PeerWaitState mPeerWaitState;
 };
 } // namespace link_prober
 

--- a/src/link_prober/PeerWaitState.cpp
+++ b/src/link_prober/PeerWaitState.cpp
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "link_prober/PeerActiveState.h"
+#include "link_prober/PeerWaitState.h"
+#include "link_prober/PeerUnknownState.h"
+#include "link_prober/LinkProberStateMachineBase.h"
+
+#include "common/MuxLogger.h"
+
+namespace link_prober
+{
+
+//
+// ---> PeerWaitState(LinkProberStateMachineBase &stateMachine, common::MuxPortConfig &muxPortConfig);
+//
+// class constructor
+//
+PeerWaitState::PeerWaitState(
+    LinkProberStateMachineBase &stateMachine,
+    common::MuxPortConfig &muxPortConfig
+)
+    : LinkProberState(stateMachine, muxPortConfig)
+{
+}
+
+//
+// ---> handleEvent(IcmpPeerActiveEvent &event);
+//
+// handle IcmpPeerActiveEvent from LinkProber
+//
+LinkProberState *PeerWaitState::handleEvent(IcmpPeerActiveEvent &event)
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *>(getStateMachine());
+    LinkProberState *nextState;
+
+    if (++mPeerActiveEvent >= getMuxPortConfig().getPositiveStateChangeRetryCount()) {
+        nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerActiveState());
+    } else {
+        nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerWaitState());
+    }
+
+    return nextState;
+}
+
+//
+// ---> handleEvent(IcmpPeerUnknownEvent &event);
+//
+// handle IcmpPeerUnknownEvent from LinkProber
+//
+LinkProberState *PeerWaitState::handleEvent(IcmpPeerUnknownEvent &event)
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *>(getStateMachine());
+    LinkProberState *nextState;
+
+    if (++mPeerUnknownEvent >= getMuxPortConfig().getNegativeStateChangeRetryCount()) {
+        nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerUnknownState());
+    } else {
+        nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerWaitState());
+    }
+
+    return nextState;
+}
+
+//
+// ---> resetState();
+//
+// reset current state attributes
+//
+void PeerWaitState::resetState()
+{
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
+    mPeerActiveEvent = 0;
+    mPeerUnknownEvent = 0;
+}
+
+} /* namespace link_prober */

--- a/src/link_prober/PeerWaitState.cpp
+++ b/src/link_prober/PeerWaitState.cpp
@@ -49,6 +49,7 @@ LinkProberState *PeerWaitState::handleEvent(IcmpPeerActiveEvent &event)
     LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *>(getStateMachine());
     LinkProberState *nextState;
 
+    mPeerUnknownEvent = 0;
     if (++mPeerActiveEvent >= getMuxPortConfig().getPositiveStateChangeRetryCount()) {
         nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerActiveState());
     } else {
@@ -70,6 +71,7 @@ LinkProberState *PeerWaitState::handleEvent(IcmpPeerUnknownEvent &event)
     LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *>(getStateMachine());
     LinkProberState *nextState;
 
+    mPeerActiveEvent = 0;
     if (++mPeerUnknownEvent >= getMuxPortConfig().getNegativeStateChangeRetryCount()) {
         nextState = dynamic_cast<LinkProberState *>(stateMachine->getPeerUnknownState());
     } else {

--- a/src/link_prober/PeerWaitState.h
+++ b/src/link_prober/PeerWaitState.h
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINK_PROBER_PEERWAITSTATE_H_
+#define LINK_PROBER_PEERWAITSTATE_H_
+
+#include <stdint.h>
+
+#include "LinkProberState.h"
+
+namespace link_prober
+{
+class LinkProberStateMachineBase;
+
+/**
+ *@class PeerWaitState
+ *
+ *@brief maintains peer Wait state of LinkProber
+ */
+class PeerWaitState : public LinkProberState
+{
+public:
+    /**
+     *@method PeerWaitState
+     *
+     *@brief class default constructor
+     */
+    PeerWaitState() = delete;
+
+    /**
+     *@method PeerWaitState
+     *
+     *@brief class copy constructor
+     *
+     *@param PeerWaitState (in)  reference to PeerWaitState object to be copied
+     */
+    PeerWaitState(const PeerWaitState &) = delete;
+
+    /**
+     *@method PeerWaitState
+     *
+     *@brief class constructor
+     *
+     *@param stateMachine (in)   reference to LinkProberStateMachineBase
+     *@param muxPortConfig (in)  reference to MuxPortConfig object
+     */
+    PeerWaitState(
+        LinkProberStateMachineBase &stateMachine,
+        common::MuxPortConfig &muxPortConfig
+    );
+
+    /**
+     *@method ~PeerWaitState
+     *
+     *@brief class destructor
+     */
+    virtual ~PeerWaitState() = default;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerActiveEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerActiveEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerActiveEvent &event) override;
+
+    /**
+     *@method handleEvent
+     *
+     *@brief handle IcmpPeerUnknownEvent from LinkProber
+     *
+     *@param event (in)  reference to IcmpPeerUnknownEvent
+     *
+     *@return pointer to next LinkProberState
+     */
+    virtual LinkProberState *handleEvent(IcmpPeerUnknownEvent &event) override;
+
+    /**
+     *@method resetState
+     *
+     *@brief reset current state attributes
+     *
+     *@return none
+     */
+    virtual void resetState() override;
+
+    /**
+     *@method getStateLabel
+     *
+     *@brief getter for LinkeProberState label
+     *
+     *@return LinkProberState Unknown label
+     */
+    virtual LinkProberState::Label getStateLabel() override { return LinkProberState::Label::PeerWait; };
+
+private:
+    uint8_t mPeerActiveEvent = 0;
+    uint8_t mPeerUnknownEvent = 0;
+};
+
+} /* namespace link_prober */
+
+#endif /* LINK_PROBER_PEERWAITSTATE_H_ */

--- a/src/link_prober/WaitState.cpp
+++ b/src/link_prober/WaitState.cpp
@@ -81,6 +81,7 @@ LinkProberState* WaitState::handleEvent(IcmpSelfEvent &event)
     LinkProberState *nextState;
 
     mPeerEventCount = 0;
+    mUnknownEventCount = 0;
     if (++mSelfEventCount >= getMuxPortConfig().getPositiveStateChangeRetryCount()) {
         nextState = dynamic_cast<LinkProberState *> (stateMachine->getActiveState());
     }
@@ -130,6 +131,7 @@ void WaitState::resetState()
     MUXLOGDEBUG(getMuxPortConfig().getPortName());
 
     mSelfEventCount = 0;
+    mUnknownEventCount = 0;
     mPeerEventCount = 0;
 }
 

--- a/src/link_prober/WaitState.h
+++ b/src/link_prober/WaitState.h
@@ -130,6 +130,7 @@ public:
 private:
     uint8_t mSelfEventCount = 0;
     uint8_t mPeerEventCount = 0;
+    uint8_t mUnknownEventCount = 0;
 };
 
 } /* namespace link_prober */

--- a/src/link_prober/subdir.mk
+++ b/src/link_prober/subdir.mk
@@ -3,6 +3,7 @@ CPP_SRCS += \
     ./src/link_prober/ActiveState.cpp \
     ./src/link_prober/PeerActiveState.cpp \
     ./src/link_prober/PeerUnknownState.cpp \
+    ./src/link_prober/PeerWaitState.cpp \
     ./src/link_prober/IcmpPayload.cpp \
     ./src/link_prober/LinkProber.cpp \
     ./src/link_prober/LinkProberState.cpp \
@@ -17,6 +18,7 @@ OBJS += \
     ./src/link_prober/ActiveState.o \
     ./src/link_prober/PeerActiveState.o \
     ./src/link_prober/PeerUnknownState.o \
+    ./src/link_prober/PeerWaitState.o \
     ./src/link_prober/IcmpPayload.o \
     ./src/link_prober/LinkProber.o \
     ./src/link_prober/LinkProberState.o \
@@ -31,6 +33,7 @@ CPP_DEPS += \
     ./src/link_prober/ActiveState.d \
     ./src/link_prober/PeerActiveState.d \
     ./src/link_prober/PeerUnknownState.d \
+    ./src/link_prober/PeerWaitState.d \
     ./src/link_prober/IcmpPayload.d \
     ./src/link_prober/LinkProber.d \
     ./src/link_prober/LinkProberState.d \

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -40,7 +40,14 @@ FakeDbInterface::FakeDbInterface(mux::MuxManager *muxManager, boost::asio::io_se
 
 void FakeDbInterface::setMuxState(const std::string &portName, mux_state::MuxState::Label label)
 {
+    mLastSetMuxState = label;
     mSetMuxStateInvokeCount++;
+}
+
+void FakeDbInterface::setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label)
+{
+    mLastSetPeerMuxState = label;
+    mSetPeerMuxStateInvokeCount++;
 }
 
 void FakeDbInterface::getMuxState(const std::string &portName)

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -37,6 +37,7 @@ public:
     virtual ~FakeDbInterface() = default;
 
     virtual void setMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
+    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label);
     virtual void getMuxState(const std::string &portName) override;
     virtual void probeMuxState(const std::string &portName) override;
     virtual void setMuxLinkmgrState(
@@ -67,7 +68,11 @@ public:
 
     uint32_t mMuxStateRequest[mux_state::MuxState::Label::Count] = {0, 0, 0, 0};
 
+    mux_state::MuxState::Label mLastSetMuxState;
+    mux_state::MuxState::Label mLastSetPeerMuxState;
+
     uint32_t mSetMuxStateInvokeCount = 0;
+    uint32_t mSetPeerMuxStateInvokeCount = 0;
     uint32_t mGetMuxStateInvokeCount = 0;
     uint32_t mProbeMuxStateInvokeCount = 0;
     uint32_t mSetMuxLinkmgrStateInvokeCount = 0;

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -37,7 +37,7 @@ public:
     virtual ~FakeDbInterface() = default;
 
     virtual void setMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
-    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label);
+    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
     virtual void getMuxState(const std::string &portName) override;
     virtual void probeMuxState(const std::string &portName) override;
     virtual void setMuxLinkmgrState(

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -42,12 +42,11 @@ void FakeLinkProber::postLinkProberEvent(E &e)
 {
     boost::asio::io_service::strand& strand = mLinkProberStateMachine->getStrand();
     boost::asio::io_service &ioService = strand.context();
-    ioService.post(strand.wrap(boost::bind(
-        static_cast<void (link_prober::LinkProberStateMachineBase::*) (decltype(e))>
-            (&link_prober::LinkProberStateMachineBase::processEvent<decltype(e)>),
-        mLinkProberStateMachine,
-        e
-    )));
+    ioService.post(
+        strand.wrap(
+            [this, &e]() { mLinkProberStateMachine->processEvent(e); }
+        )
+    );
 }
 
 template
@@ -58,6 +57,12 @@ void FakeLinkProber::postLinkProberEvent<link_prober::IcmpPeerEvent&>(link_probe
 
 template
 void FakeLinkProber::postLinkProberEvent<link_prober::IcmpUnknownEvent&>(link_prober::IcmpUnknownEvent &event);
+
+template
+void FakeLinkProber::postLinkProberEvent<link_prober::IcmpPeerActiveEvent&>(link_prober::IcmpPeerActiveEvent &event);
+
+template
+void FakeLinkProber::postLinkProberEvent<link_prober::IcmpPeerUnknownEvent&>(link_prober::IcmpPeerUnknownEvent &event);
 
 void FakeLinkProber::postSuspendTimerExpiredEvent()
 {

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -35,7 +35,8 @@ FakeMuxPort::FakeMuxPort(
     common::MuxConfig &muxConfig,
     std::string &portName,
     uint16_t serverId,
-    boost::asio::io_service &ioService
+    boost::asio::io_service &ioService,
+    common::MuxPortConfig::PortCableType portCableType
 ) :
     mux::MuxPort(
         dbInterface,
@@ -43,7 +44,7 @@ FakeMuxPort::FakeMuxPort(
         portName,
         serverId,
         ioService,
-        common::MuxPortConfig::PortCableType::ActiveStandby
+        portCableType
     ),
     mActiveStandbyStateMachinePtr(
         std::dynamic_pointer_cast<link_manager::ActiveStandbyStateMachine>(getLinkManagerStateMachinePtr())

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -47,6 +47,7 @@ public:
 
     void activateStateMachine();
 
+    std::shared_ptr<link_manager::ActiveActiveStateMachine> getActiveActiveStateMachinePtr() { return mActiveActiveStateMachinePtr; }
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> getActiveStandbyStateMachinePtr() { return mActiveStandbyStateMachinePtr; }
     const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getLinkManagerStateMachinePtr()->getCompositeState(); };
     link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getLinkManagerStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
@@ -55,6 +56,12 @@ public:
 
     bool getPendingMuxModeChange() { return getActiveStandbyStateMachinePtr()->mPendingMuxModeChange; };
     common::MuxPortConfig::Mode getTargetMuxMode() { return getActiveStandbyStateMachinePtr()->mTargetMuxMode; };
+
+    link_prober::LinkProberState::Label getPeerLinkProberState() { return getActiveActiveStateMachinePtr()->mPeerLinkProberState; };
+    mux_state::MuxState::Label getPeerMuxState() { return getActiveActiveStateMachinePtr()->mPeerMuxState; };
+
+    inline void initLinkProberActiveActive();
+    inline void initLinkProberActiveStandby();
 
     std::shared_ptr<link_manager::ActiveActiveStateMachine> mActiveActiveStateMachinePtr;
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> mActiveStandbyStateMachinePtr;

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -41,20 +41,22 @@ public:
         common::MuxConfig& muxConfig,
         std::string& portName,
         uint16_t serverId,
-        boost::asio::io_service& ioService);
+        boost::asio::io_service& ioService,
+        common::MuxPortConfig::PortCableType portCableType = common::MuxPortConfig::PortCableType::ActiveStandby);
     virtual ~FakeMuxPort() = default;
 
     void activateStateMachine();
 
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> getActiveStandbyStateMachinePtr() { return mActiveStandbyStateMachinePtr; }
-    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getActiveStandbyStateMachinePtr()->getCompositeState(); };
-    link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getActiveStandbyStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
-    mux_state::MuxStateMachine& getMuxStateMachine() { return getActiveStandbyStateMachinePtr()->getMuxStateMachine(); };
-    link_state::LinkStateMachine& getLinkStateMachine() { return getActiveStandbyStateMachinePtr()->getLinkStateMachine(); };
+    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getLinkManagerStateMachinePtr()->getCompositeState(); };
+    link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getLinkManagerStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
+    mux_state::MuxStateMachine& getMuxStateMachine() { return getLinkManagerStateMachinePtr()->getMuxStateMachine(); };
+    link_state::LinkStateMachine& getLinkStateMachine() { return getLinkManagerStateMachinePtr()->getLinkStateMachine(); };
 
     bool getPendingMuxModeChange() { return getActiveStandbyStateMachinePtr()->mPendingMuxModeChange; };
     common::MuxPortConfig::Mode getTargetMuxMode() { return getActiveStandbyStateMachinePtr()->mTargetMuxMode; };
 
+    std::shared_ptr<link_manager::ActiveActiveStateMachine> mActiveActiveStateMachinePtr;
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> mActiveStandbyStateMachinePtr;
     std::shared_ptr<FakeLinkProber> mFakeLinkProber;
 };

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -1,0 +1,398 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "LinkManagerStateMachineActiveActiveTest.h"
+#include "link_prober/LinkProberStateMachineBase.h"
+
+#define VALIDATE_STATE(p, m, l)                                                     \
+    do {                                                                            \
+        mTestCompositeState = mFakeMuxPort.getCompositeState();                     \
+        EXPECT_EQ(ps(mTestCompositeState), link_prober::LinkProberState::Label::p); \
+        EXPECT_EQ(ms(mTestCompositeState), mux_state::MuxState::Label::m);          \
+        EXPECT_EQ(ls(mTestCompositeState), link_state::LinkState::Label::l);        \
+    } while (0)
+
+#define VALIDATE_PEER_STATE(p, m)                                                                 \
+    do {                                                                                          \
+        EXPECT_EQ(mFakeMuxPort.getPeerLinkProberState(), link_prober::LinkProberState::Label::p); \
+        EXPECT_EQ(mFakeMuxPort.getPeerMuxState(), mux_state::MuxState::Label::m);                 \
+    } while (0)
+
+namespace test
+{
+
+LinkManagerStateMachineActiveActiveTest::LinkManagerStateMachineActiveActiveTest()
+    : mDbInterfacePtr(std::make_shared<FakeDbInterface>(&mIoService)),
+      mFakeMuxPort(
+          mDbInterfacePtr,
+          mMuxConfig,
+          mPortName,
+          mServerId,
+          mIoService,
+          mPortCableType
+      )
+{
+    mMuxConfig.setTimeoutIpv4_msec(10);
+    mMuxConfig.setPositiveStateChangeRetryCount(mPositiveUpdateCount);
+    mMuxConfig.setMuxStateChangeRetryCount(mPositiveUpdateCount);
+    mMuxConfig.setLinkStateChangeRetryCount(mPositiveUpdateCount);
+}
+
+void LinkManagerStateMachineActiveActiveTest::runIoService(uint32_t count)
+{
+    if (count == 0) {
+        if (mIoService.stopped()) {
+            mIoService.restart();
+        }
+        mIoService.run();
+    }
+
+    for (uint8_t i = 0; i < count; i++) {
+        if (mIoService.stopped()) {
+            mIoService.restart();
+        }
+        mIoService.run_one();
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::pollIoService(uint32_t count)
+{
+    if (count == 0) {
+        if (mIoService.stopped()) {
+            mIoService.restart();
+        }
+        mIoService.poll();
+    }
+
+    for (uint8_t i = 0; i < count; i++) {
+        if (mIoService.stopped()) {
+            mIoService.restart();
+        }
+        mIoService.poll_one();
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count)
+{
+    switch (label) {
+        case link_prober::LinkProberState::Active:
+            for (uint8_t i = 0; i < mMuxConfig.getPositiveStateChangeRetryCount(); i++) {
+                mFakeMuxPort.mFakeLinkProber->postLinkProberEvent<link_prober::IcmpSelfEvent&>(
+                    link_prober::LinkProberStateMachineBase::getIcmpSelfEvent()
+                );
+                runIoService(count);
+            }
+            break;
+        case link_prober::LinkProberState::Unknown:
+            for (uint8_t i = 0; i < mMuxConfig.getNegativeStateChangeRetryCount(); i++) {
+                mFakeMuxPort.mFakeLinkProber->postLinkProberEvent<link_prober::IcmpUnknownEvent&>(
+                    link_prober::LinkProberStateMachineBase::getIcmpUnknownEvent()
+                );
+                runIoService(count);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::postPeerLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count)
+{
+    switch (label) {
+        case link_prober::LinkProberState::PeerActive:
+            for (uint8_t i = 0; i < mMuxConfig.getPositiveStateChangeRetryCount(); i++) {
+                mFakeMuxPort.mFakeLinkProber->postLinkProberEvent<link_prober::IcmpPeerActiveEvent&>(
+                    link_prober::LinkProberStateMachineBase::getIcmpPeerActiveEvent()
+                );
+                runIoService(count);
+            }
+            break;
+        case link_prober::LinkProberState::PeerUnknown:
+            for (uint8_t i = 0; i < mMuxConfig.getNegativeStateChangeRetryCount(); i++) {
+                mFakeMuxPort.mFakeLinkProber->postLinkProberEvent<link_prober::IcmpPeerUnknownEvent&>(
+                    link_prober::LinkProberStateMachineBase::getIcmpPeerUnknownEvent()
+                );
+                runIoService(count);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::postMuxEvent(mux_state::MuxState::Label label, uint32_t count)
+{
+    mux_state::MuxStateMachine& muxStateMachine = mFakeMuxPort.getMuxStateMachine();
+    for (uint8_t i = 0; i < mMuxConfig.getMuxStateChangeRetryCount(); i++) {
+        switch (label) {
+            case mux_state::MuxState::Active:
+                muxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getActiveEvent());
+                break;
+            case mux_state::MuxState::Standby:
+                muxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getStandbyEvent());
+                break;
+            case mux_state::MuxState::Unknown:
+                muxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getUnknownEvent());
+                break;
+            case mux_state::MuxState::Error:
+                muxStateMachine.postMuxStateEvent(mux_state::MuxStateMachine::getErrorEvent());
+                break;
+            default:
+                break;
+        }
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::postLinkEvent(link_state::LinkState::Label label, uint32_t count)
+{
+    link_state::LinkStateMachine& linkStateMachine = mFakeMuxPort.getLinkStateMachine();
+    for (uint8_t i = 0; i < mMuxConfig.getLinkStateChangeRetryCount(); i++) {
+        switch (label) {
+            case link_state::LinkState::Up:
+                linkStateMachine.postLinkStateEvent(link_state::LinkStateMachine::getUpEvent());
+                break;
+            case link_state::LinkState::Down:
+                linkStateMachine.postLinkStateEvent(link_state::LinkStateMachine::getDownEvent());
+                break;
+            default:
+                break;
+        }
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::handleMuxState(std::string state, uint32_t count)
+{
+    for (uint8_t i = 0; i < mPositiveUpdateCount; i++) {
+        mFakeMuxPort.handleMuxState(state);
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::handlePeerMuxState(std::string state, uint32_t count)
+{
+    for (uint8_t i = 0; i < mPositiveUpdateCount; i++) {
+        mFakeMuxPort.handlePeerMuxState(state);
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::handleProbeMuxState(std::string state, uint32_t count)
+{
+    for (uint8_t i = 0; i < mPositiveUpdateCount; i++) {
+        mFakeMuxPort.handleProbeMuxState(state);
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::handleLinkState(std::string linkState, uint32_t count)
+{
+    for (uint8_t i = 0; i < mMuxConfig.getLinkStateChangeRetryCount(); i++) {
+        mFakeMuxPort.handleLinkState(linkState);
+        runIoService(count);
+    }
+}
+
+void LinkManagerStateMachineActiveActiveTest::handleMuxConfig(std::string config, uint32_t count)
+{
+    mFakeMuxPort.handleMuxConfig(config);
+    runIoService(count);
+}
+
+void LinkManagerStateMachineActiveActiveTest::activateStateMachine()
+{
+    mFakeMuxPort.activateStateMachine();
+}
+
+void LinkManagerStateMachineActiveActiveTest::setMuxActive()
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
+void LinkManagerStateMachineActiveActiveTest::setMuxStandby()
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActive)
+{
+    setMuxActive();
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberUnknown)
+{
+    setMuxActive();
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSuspendTxProbeCallCount, 1);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkDown)
+{
+    setMuxActive();
+
+    postLinkEvent(link_state::LinkState::Label::Down, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Down);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    postLinkEvent(link_state::LinkState::Label::Up, 2);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
+{
+    setMuxActive();
+
+    handleMuxConfig("standby", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxConfig("auto", 1);
+    handleProbeMuxState("standby", 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+    VALIDATE_STATE(Active, Active, Up);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerActive)
+{
+    setMuxActive();
+
+    VALIDATE_PEER_STATE(PeerWait, Wait);
+
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerActive);
+    VALIDATE_PEER_STATE(PeerActive, Active);
+    EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 0);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerUnknown)
+{
+    setMuxActive();
+
+    VALIDATE_PEER_STATE(PeerWait, Wait);
+
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerUnknown, 3);
+    VALIDATE_PEER_STATE(PeerUnknown, Standby);
+    EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetPeerMuxState, mux_state::MuxState::Label::Standby);
+
+    handlePeerMuxState("standby", 1);
+    VALIDATE_PEER_STATE(PeerUnknown, Standby);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandby)
+{
+    setMuxStandby();
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyLinkDown)
+{
+    setMuxStandby();
+
+    postLinkEvent(link_state::LinkState::Label::Down, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    postLinkEvent(link_state::LinkState::Label::Up, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    VALIDATE_STATE(Unknown, Standby, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyLinkProberPeerActive)
+{
+    setMuxStandby();
+
+    VALIDATE_PEER_STATE(PeerWait, Wait);
+
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerActive);
+    VALIDATE_PEER_STATE(PeerActive, Active);
+    EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 0);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyLinkProberPeerUnknown)
+{
+    setMuxStandby();
+
+    VALIDATE_PEER_STATE(PeerWait, Wait);
+
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerUnknown);
+    VALIDATE_PEER_STATE(PeerUnknown, Wait);
+    EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 0);
+}
+
+} /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LINKMANAGERSTATEMACHINEACTIVEACTIVETEST_H_
+#define LINKMANAGERSTATEMACHINEACTIVEACTIVETEST_H_
+
+#include "gtest/gtest.h"
+
+#include "FakeMuxPort.h"
+#include "FakeLinkProber.h"
+
+namespace test
+{
+
+class LinkManagerStateMachineActiveActiveTest : public ::testing::Test
+{
+public:
+    LinkManagerStateMachineActiveActiveTest();
+    virtual ~LinkManagerStateMachineActiveActiveTest() = default;
+
+    void runIoService(uint32_t count = 0);
+    void pollIoService(uint32_t count = 0);
+    void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
+    void postPeerLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
+    void postMuxEvent(mux_state::MuxState::Label label, uint32_t count = 0);
+    void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0);
+    void postSuspendTimerExpiredEvent(uint32_t count = 0);
+    void handleMuxState(std::string, uint32_t count = 0);
+    void handlePeerMuxState(std::string, uint32_t count = 0);
+    void handleProbeMuxState(std::string, uint32_t count = 0);
+    void handleLinkState(std::string linkState, uint32_t count = 0);
+    void handleMuxConfig(std::string config, uint32_t count = 0);
+    void activateStateMachine();
+    void setMuxActive();
+    void setMuxStandby();
+
+public:
+    boost::asio::io_service mIoService;
+    common::MuxConfig mMuxConfig;
+    std::shared_ptr<FakeDbInterface> mDbInterfacePtr;
+    std::string mPortName = "Ethernet10";
+    std::string mSmartNicIpAddress = "192.168.1.20";
+    common::MuxPortConfig::PortCableType mPortCableType = common::MuxPortConfig::PortCableType::ActiveActive;
+    uint16_t mServerId = 10;
+
+    FakeMuxPort mFakeMuxPort;
+    link_manager::ActiveStandbyStateMachine::CompositeState mTestCompositeState;
+
+    uint8_t mPositiveUpdateCount = 2;
+};
+
+} /* namespace test */
+
+#endif /* LINKMANAGERSTATEMACHINEACTIVEACTIVETEST_H_ */

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -212,6 +212,9 @@ void MuxManagerTest::initLinkProberActiveActive(std::shared_ptr<link_manager::Ac
     linkManagerStateMachineActiveActive->setUpdateEthernetFrameFnPtr(
         boost::bind(&FakeLinkProber::updateEthernetFrame, mFakeLinkProber.get())
     );
+    linkManagerStateMachineActiveActive->setProbePeerTorFnPtr(
+        boost::bind(&FakeLinkProber::probePeerTor, mFakeLinkProber.get())
+    );
     linkManagerStateMachineActiveActive->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -30,6 +30,10 @@
 namespace test
 {
 
+const std::string MuxManagerTest::PortName = "Ethernet0";
+const std::string MuxManagerTest::ServerAddress = "192.168.0.1";
+const std::string MuxManagerTest::SoCAddress = "192.168.0.2";
+
 MuxManagerTest::MuxManagerTest() :
     mMuxManagerPtr(std::make_shared<mux::MuxManager> ()),
     mDbInterfacePtr(std::make_shared<FakeDbInterface> (mMuxManagerPtr.get(), &mMuxManagerPtr->getIoService())),
@@ -44,6 +48,14 @@ void MuxManagerTest::runIoService(uint32_t count)
 {
     for (uint32_t i = 0; i < count; i++) {
         mMuxManagerPtr->getIoService().run_one();
+        mMuxManagerPtr->getIoService().reset();
+    }
+}
+
+void MuxManagerTest::pollIoService(uint32_t count)
+{
+    for (uint32_t i = 0; i < count; i++) {
+        mMuxManagerPtr->getIoService().poll_one();
         mMuxManagerPtr->getIoService().reset();
     }
 }
@@ -131,14 +143,17 @@ link_manager::LinkManagerStateMachineBase::CompositeState MuxManagerTest::getCom
 
 common::MuxPortConfig::PortCableType MuxManagerTest::getPortCableType(const std::string &port)
 {
-    return mMuxManagerPtr->mPortCableTypeMap.at(port);
+    return mMuxManagerPtr->getMuxPortCableType(port);
 }
 
 void MuxManagerTest::processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers)
 {
     mDbInterfacePtr->processServerIpAddress(servers);
+}
 
-    EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
+void MuxManagerTest::processSoCIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers)
+{
+    mDbInterfacePtr->processSoCIpAddress(servers);
 }
 
 void MuxManagerTest::processServerMacAddress(
@@ -185,12 +200,80 @@ void MuxManagerTest::updatePortCableType(const std::string &port, const std::str
     mMuxManagerPtr->updatePortCableType(port, cableType);
 }
 
-void MuxManagerTest::createPort(std::string port)
+void MuxManagerTest::initLinkProberActiveActive(std::shared_ptr<link_manager::ActiveActiveStateMachine> linkManagerStateMachineActiveActive)
+{
+    mFakeLinkProber = std::make_shared<FakeLinkProber> (linkManagerStateMachineActiveActive->getLinkProberStateMachinePtr().get());
+    linkManagerStateMachineActiveActive->setInitializeProberFnPtr(
+        boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveActive->setStartProbingFnPtr(
+        boost::bind(&FakeLinkProber::startProbing, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveActive->setUpdateEthernetFrameFnPtr(
+        boost::bind(&FakeLinkProber::updateEthernetFrame, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveActive->setSuspendTxFnPtr(
+        boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
+    );
+    linkManagerStateMachineActiveActive->setResumeTxFnPtr(
+        boost::bind(&FakeLinkProber::resumeTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveActive->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveActive->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
+
+    linkManagerStateMachineActiveActive->mComponentInitState.set(0);
+}
+
+void MuxManagerTest::initLinkProberActiveStandby(std::shared_ptr<link_manager::ActiveStandbyStateMachine> linkManagerStateMachineActiveStandby)
+{
+    mFakeLinkProber = std::make_shared<FakeLinkProber> (linkManagerStateMachineActiveStandby->getLinkProberStateMachinePtr().get());
+    linkManagerStateMachineActiveStandby->setInitializeProberFnPtr(
+        boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setStartProbingFnPtr(
+        boost::bind(&FakeLinkProber::startProbing, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setUpdateEthernetFrameFnPtr(
+        boost::bind(&FakeLinkProber::updateEthernetFrame, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setSuspendTxFnPtr(
+        boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
+    );
+    linkManagerStateMachineActiveStandby->setShutdownTxFnPtr(
+        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setRestartTxFnPtr(
+        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setDecreaseIntervalFnPtr(
+        boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
+    );
+    linkManagerStateMachineActiveStandby->setRevertIntervalFnPtr(
+        boost::bind(&FakeLinkProber::revertProbeIntervalAfterSwitchComplete, mFakeLinkProber.get())
+    );
+    linkManagerStateMachineActiveStandby->setSendPeerSwitchCommandFnPtr(
+        boost::bind(&FakeLinkProber::sendPeerSwitchCommand, mFakeLinkProber.get())
+    );
+
+    linkManagerStateMachineActiveStandby->mComponentInitState.set(0);
+}
+
+void MuxManagerTest::generateServerMac(const std::string &port, std::array<uint8_t, ETHER_ADDR_LEN> &address)
+{
+    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
+    mMuxManagerPtr->generateServerMac(muxPortPtr->mMuxPortConfig.getServerId(), address);
+}
+
+void MuxManagerTest::createPort(std::string port, common::MuxPortConfig::PortCableType portCableType)
 {
     EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 0);
     EXPECT_TRUE(mMuxManagerPtr->mPortCableTypeMap.size() == 0);
 
-    updatePortCableType(port, "active-standby");
+    updatePortCableType(port, PortCableTypeValues[portCableType]);
     EXPECT_TRUE(mMuxManagerPtr->mPortCableTypeMap.size() == 1);
 
     std::deque<swss::KeyOpFieldsValuesTuple> entries = {
@@ -198,57 +281,53 @@ void MuxManagerTest::createPort(std::string port)
     };
 
     mDbInterfacePtr->processLinkStateNotifiction(entries);
-    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap["Ethernet0"];
-    std::shared_ptr<link_manager::ActiveStandbyStateMachine> linkManagerStateMachine = std::dynamic_pointer_cast<link_manager::ActiveStandbyStateMachine> (
-        muxPortPtr->getLinkManagerStateMachinePtr()
-    );
+    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
+    std::shared_ptr<link_manager::LinkManagerStateMachineBase> linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachinePtr();
 
     EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::LinkStateComponent) == 0);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachineBase::LinkStateComponent) == 0);
 
     runIoService();
 
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::LinkStateComponent) == 1);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachineBase::LinkStateComponent) == 1);
 
     // Initialize a FakeLinkProber
-    mFakeLinkProber = std::make_shared<FakeLinkProber> (linkManagerStateMachine->getLinkProberStateMachinePtr().get());
-    linkManagerStateMachine->setInitializeProberFnPtr(
-        boost::bind(&FakeLinkProber::initialize, mFakeLinkProber.get())
-    );
-    linkManagerStateMachine->setStartProbingFnPtr(
-        boost::bind(&FakeLinkProber::startProbing, mFakeLinkProber.get())
-    );
-    linkManagerStateMachine->setUpdateEthernetFrameFnPtr(
-        boost::bind(&FakeLinkProber::updateEthernetFrame, mFakeLinkProber.get())
-    );
-    linkManagerStateMachine->setSuspendTxFnPtr(
-        boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
-    );
-    linkManagerStateMachine->setShutdownTxFnPtr(
-        boost::bind(&FakeLinkProber::shutdownTxProbes, mFakeLinkProber.get())
-    );
-    linkManagerStateMachine->setRestartTxFnPtr(
-        boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
-    );
-    linkManagerStateMachine->setDecreaseIntervalFnPtr(
-        boost::bind(&FakeLinkProber::decreaseProbeIntervalAfterSwitch, mFakeLinkProber.get(), boost::placeholders::_1)
-    );
-    linkManagerStateMachine->setRevertIntervalFnPtr(
-        boost::bind(&FakeLinkProber::revertProbeIntervalAfterSwitchComplete, mFakeLinkProber.get())
-    );
+    switch (portCableType) {
+        case common::MuxPortConfig::PortCableType::ActiveActive: {
+            initLinkProberActiveActive(std::dynamic_pointer_cast<link_manager::ActiveActiveStateMachine>(linkManagerStateMachine));
+            break;
+        }
+        case common::MuxPortConfig::PortCableType::ActiveStandby: {
+            initLinkProberActiveStandby(std::dynamic_pointer_cast<link_manager::ActiveStandbyStateMachine>(linkManagerStateMachine));
+            break;
+        }
+        default:
+            break;
+    }
 
-    linkManagerStateMachine->mComponentInitState.set(0);
-
-    std::string ipAddress = "192.168.0.1";
+    std::string ipAddress = ServerAddress;
+    std::string iPAddressSoC = SoCAddress;
     std::vector<swss::KeyOpFieldsValuesTuple> servers;
-    servers = {
-        {port, "SET", {{"server_ipv4", ipAddress + "/32"}, {"server_ipv6", "2603:10e1:100:f::1/128"}}},
-        {"Ethernet1234", "SET", {{"server_ipv4", "250.260.270.280/32"}}},
-    };
+    if (portCableType == common::MuxPortConfig::PortCableType::ActiveActive) {
+        servers = {
+            {port, "SET", {{"server_ipv4", ipAddress + "/32"}, {"server_ipv6", "2603:10e1:100:f::1/128"}, {"soc_ipv4", iPAddressSoC + "/32"}, {"cable_type", "active-active"}}},
+            {"Ethernet1234", "SET", {{"server_ipv4", "250.260.270.280/32"}}},
+        };
+
+    } else if (portCableType == common::MuxPortConfig::PortCableType::ActiveStandby) {
+        servers = {
+            {port, "SET", {{"server_ipv4", ipAddress + "/32"}, {"server_ipv6", "2603:10e1:100:f::1/128"}}},
+            {"Ethernet1234", "SET", {{"server_ipv4", "250.260.270.280/32"}}},
+        };
+    }
 
     processServerIpAddress(servers);
+    pollIoService();
+    EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
+    processSoCIpAddress(servers);
+    pollIoService();
+    EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
 
-    runIoService();
 
     entries.clear();
     entries = {
@@ -257,31 +336,31 @@ void MuxManagerTest::createPort(std::string port)
 
     mDbInterfacePtr->processMuxStateNotifiction(entries);
     EXPECT_TRUE(mMuxManagerPtr->mPortMap.size() == 1);
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::MuxStateComponent) == 0);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachineBase::MuxStateComponent) == 0);
 
     runIoService();
 
-    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::ActiveStandbyStateMachine::MuxStateComponent) == 1);
+    EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachineBase::MuxStateComponent) == 1);
 }
 
 TEST_F(MuxManagerTest, UpdatePortCableTypeActiveStandby)
 {
-    std::string port = "Ethernet0";
+    std::string port = MuxManagerTest::PortName;
     updatePortCableType(port, "active-standby");
     EXPECT_TRUE(getPortCableType(port) == common::MuxPortConfig::PortCableType::ActiveStandby);
 }
 
 TEST_F(MuxManagerTest, UpdatePortCableTypeUnsupported)
 {
-    std::string port = "Ethernet0";
+    std::string port = MuxManagerTest::PortName;
     updatePortCableType(port, "active-standby-active");
     EXPECT_TRUE(getPortCableType(port) == common::MuxPortConfig::PortCableType::ActiveStandby);
 }
 
 TEST_F(MuxManagerTest, AddPort)
 {
-    std::string port = "Ethernet0";
-    std::string ipAddress = "192.168.0.1";
+    std::string port = MuxManagerTest::PortName;
+    std::string ipAddress = MuxManagerTest::ServerAddress;
 
     createPort(port);
 
@@ -296,6 +375,29 @@ TEST_F(MuxManagerTest, AddPort)
 
     EXPECT_TRUE(bladeMacAddress == serverMac);
     EXPECT_TRUE(getBladeIpv4Address(port).to_string() == ipAddress);
+}
+
+TEST_F(MuxManagerTest, AddPortActiveActive)
+{
+    std::string port = MuxManagerTest::PortName;
+    std::string ipAddress = MuxManagerTest::ServerAddress;
+    std::string ipAddressSoC = MuxManagerTest::ServerAddress;
+
+    createPort(port, common::MuxPortConfig::ActiveActive);
+
+    std::array<uint8_t, ETHER_ADDR_LEN> serverMac = {0, 'b', 2, 'd', 4, 'f'};
+    boost::asio::ip::address serverAddress = boost::asio::ip::address::from_string(ipAddress);
+
+    updateServerMacAddress(serverAddress, serverMac.data());
+
+    runIoService();
+
+    std::array<uint8_t, ETHER_ADDR_LEN> bladeMacAddress = getBladeMacAddress(port);
+    EXPECT_TRUE(bladeMacAddress != serverMac);
+
+    std::array<uint8_t, ETHER_ADDR_LEN> knownMac;
+    generateServerMac(port, knownMac);
+    EXPECT_TRUE(bladeMacAddress == knownMac);
 }
 
 TEST_F(MuxManagerTest, Loopback2Address)
@@ -442,7 +544,7 @@ TEST_P(MuxResponseTest, MuxResponse)
 {
     std::string port = "Ethernet0";
 
-    createPort(port);
+    createPort(port, std::get<3> (GetParam()));
 
     std::deque<swss::KeyOpFieldsValuesTuple> entries = {
         {port, "SET", {{"response", std::get<0> (GetParam())}}},
@@ -458,10 +560,14 @@ INSTANTIATE_TEST_CASE_P(
     MuxState,
     MuxResponseTest,
     ::testing::Values(
-        std::make_tuple("active", 1, mux_state::MuxState::Label::Active),
-        std::make_tuple("standby", 3, mux_state::MuxState::Label::Standby),
-        std::make_tuple("unknown", 3, mux_state::MuxState::Label::Wait),
-        std::make_tuple("error", 3, mux_state::MuxState::Label::Wait)
+        std::make_tuple("active", 1, mux_state::MuxState::Label::Active, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("standby", 3, mux_state::MuxState::Label::Standby, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("unknown", 3, mux_state::MuxState::Label::Wait, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("error", 3, mux_state::MuxState::Label::Wait, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("active", 1, mux_state::MuxState::Label::Active, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("standby", 3, mux_state::MuxState::Label::Standby, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("unknown", 3, mux_state::MuxState::Label::Unknown, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("error", 3, mux_state::MuxState::Label::Unknown, common::MuxPortConfig::PortCableType::ActiveActive)
     )
 );
 
@@ -495,7 +601,7 @@ TEST_P(MuxConfigUpdateTest, MuxPortConfigUpdate)
 {
     std::string port = "Ethernet0";
 
-    createPort("Ethernet0");
+    createPort("Ethernet0", std::get<2> (GetParam()));
 
     std::string state = std::get<0> (GetParam());
     std::deque<swss::KeyOpFieldsValuesTuple> entries = {
@@ -511,9 +617,14 @@ INSTANTIATE_TEST_CASE_P(
     AutoActiveManual,
     MuxConfigUpdateTest,
     ::testing::Values(
-        std::make_tuple("auto", common::MuxPortConfig::Mode::Auto),
-        std::make_tuple("active", common::MuxPortConfig::Mode::Active),
-        std::make_tuple("manual", common::MuxPortConfig::Mode::Manual)
+        std::make_tuple("auto", common::MuxPortConfig::Mode::Auto, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("active", common::MuxPortConfig::Mode::Active, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("standby", common::MuxPortConfig::Mode::Standby, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("manual", common::MuxPortConfig::Mode::Manual, common::MuxPortConfig::PortCableType::ActiveStandby),
+        std::make_tuple("auto", common::MuxPortConfig::Mode::Auto, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("active", common::MuxPortConfig::Mode::Active, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("standby", common::MuxPortConfig::Mode::Standby, common::MuxPortConfig::PortCableType::ActiveActive),
+        std::make_tuple("manual", common::MuxPortConfig::Mode::Manual, common::MuxPortConfig::PortCableType::ActiveActive)
     )
 );
 

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -39,6 +39,8 @@ class MuxManager;
 namespace test
 {
 
+const char* PortCableTypeValues[] = {"active-standby", "active-active"};
+
 class MuxManagerTest: public testing::Test
 {
 public:
@@ -46,6 +48,7 @@ public:
     virtual ~MuxManagerTest() = default;
 
     void runIoService(uint32_t count = 1);
+    void pollIoService(uint32_t count = 1);
     common::MuxPortConfig::Mode getMode(std::string port);
     uint32_t getPositiveStateChangeRetryCount(std::string port);
     uint32_t getNegativeStateChangeRetryCount(std::string port);
@@ -60,6 +63,7 @@ public:
     void processMuxPortConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     link_manager::LinkManagerStateMachineBase::CompositeState getCompositeStateMachineState(std::string port);
     void processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
+    void processSoCIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
     void processServerMacAddress(std::string port, std::array<char, MAX_ADDR_SIZE + 1> ip, std::array<char, MAX_ADDR_SIZE + 1> mac);
     void processLoopback2InterfaceInfo(std::vector<std::string> &loopbackIntfs);
     void processTorMacAddress(std::string &mac);
@@ -68,7 +72,15 @@ public:
     void updateServerMacAddress(boost::asio::ip::address serverIp, const uint8_t *serverMac);
     void processGetMuxState(const std::string &portName, const std::string &muxState);
     void updatePortCableType(const std::string &port, const std::string &cableType);
-    void createPort(std::string port);
+    void initLinkProberActiveActive(std::shared_ptr<link_manager::ActiveActiveStateMachine> linkManagerStateMachine);
+    void initLinkProberActiveStandby(std::shared_ptr<link_manager::ActiveStandbyStateMachine> linkManagerStateMachine);
+    void generateServerMac(const std::string &portName, std::array<uint8_t, ETHER_ADDR_LEN> &address);
+    void createPort(std::string port, common::MuxPortConfig::PortCableType portCableType = common::MuxPortConfig::PortCableType::ActiveStandby);
+
+public:
+    static const std::string PortName;
+    static const std::string ServerAddress;
+    static const std::string SoCAddress;
 
 public:
     std::shared_ptr<mux::MuxManager> mMuxManagerPtr;
@@ -79,7 +91,7 @@ public:
 };
 
 class MuxResponseTest: public MuxManagerTest,
-                       public testing::WithParamInterface<std::tuple<std::string, uint32_t, mux_state::MuxState::Label>>
+                       public testing::WithParamInterface<std::tuple<std::string, uint32_t, mux_state::MuxState::Label, common::MuxPortConfig::PortCableType>>
 {
 };
 
@@ -89,7 +101,7 @@ class GetMuxStateTest: public MuxManagerTest,
 };
 
 class MuxConfigUpdateTest: public MuxManagerTest,
-                           public testing::WithParamInterface<std::tuple<std::string, common::MuxPortConfig::Mode>>
+                           public testing::WithParamInterface<std::tuple<std::string, common::MuxPortConfig::Mode, common::MuxPortConfig::PortCableType>>
 {
 };
 

--- a/test/subdir.mk
+++ b/test/subdir.mk
@@ -4,6 +4,7 @@ CPP_SRCS += \
     ./test/FakeLinkProber.cpp \
     ./test/FakeMuxPort.cpp \
     ./test/LinkManagerStateMachineTest.cpp \
+    ./test/LinkManagerStateMachineActiveActiveTest.cpp \
     ./test/LinkProberTest.cpp \
     ./test/MuxManagerTest.cpp \
     ./test/MockLinkManagerStateMachine.cpp \
@@ -15,6 +16,7 @@ OBJS_LINKMGRD_TEST += \
     ./test/FakeLinkProber.o \
     ./test/FakeMuxPort.o \
     ./test/LinkManagerStateMachineTest.o \
+    ./test/LinkManagerStateMachineActiveActiveTest.o \
     ./test/LinkProberTest.o \
     ./test/MuxManagerTest.o \
     ./test/MockLinkManagerStateMachine.o \
@@ -26,6 +28,7 @@ CPP_DEPS += \
     ./test/FakeLinkProber.d \
     ./test/FakeMuxPort.d \
     ./test/LinkManagerStateMachineTest.d \
+    ./test/LinkManagerStateMachineActiveActiveTest.d \
     ./test/LinkProberTest.d \
     ./test/MuxManagerTest.d \
     ./test/MockLinkManagerStateMachine.d \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Add link manager state machine `ActiveActiveStateMachine` to work if the port is in `active-active` cable type.

#### How did you do it?
Add `ActiveActiveStateMachine` to cover the following scenarions:
* if the mux state is active, and link prober receives unknown event, linkmgrd will try to switch the mux to standby.
* if the mux state is standby, and link prober receives active event, linkmgrd will try to switch the mux to active.
* if the mux state is active, and link down event received, linkmgrd will try to switch the mux to standby.
* if the mux state is active, and mux config set to standby, linkmgrd will try to switch the mux to standby even with link prober active event.

#### How did you verify/test it?
Add unittests to cover the above scenarios.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->