### PR TITLE
[202012] Add support to enable switchover time measurement (with link prober interval decreased to 10ms) feature

### DIFF
--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -64,6 +64,7 @@ int main(int argc, const char* argv[])
     // Constants for command line argument strings:
     //
     boost::log::trivial::severity_level level;
+    bool measureSwitchover = false;
 
     program_options::options_description description("linkmgrd options");
     description.add_options()
@@ -73,6 +74,9 @@ int main(int argc, const char* argv[])
          program_options::value<boost::log::trivial::severity_level>(&level)->value_name("<severity_level>")->
          default_value(DEFAULT_LOGGING_FILTER_LEVEL),
          "Logging verbosity level.")
+         ("measure_switchover_overhead,m",
+         program_options::bool_switch(&measureSwitchover)->default_value(false),
+         "Decrease link prober interval after switchover to better measure switchover overhead")
     ;
 
     //
@@ -111,7 +115,7 @@ int main(int argc, const char* argv[])
         link_manager::LinkManagerStateMachine::initializeTransitionFunctionTable();
 
         std::shared_ptr<mux::MuxManager> muxManagerPtr = std::make_shared<mux::MuxManager> ();
-        muxManagerPtr->initialize();
+        muxManagerPtr->initialize(measureSwitchover);
         muxManagerPtr->run();
         muxManagerPtr->deinitialize();
     }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -59,7 +59,7 @@ MuxManager::MuxManager() :
 //
 // initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db
 //
-void MuxManager::initialize()
+void MuxManager::initialize(bool enable_feature_measurement)
 {
     for (uint8_t i = 0; (mMuxConfig.getNumberOfThreads() > 2) &&
                         (i < mMuxConfig.getNumberOfThreads() - 2); i++) {
@@ -69,6 +69,8 @@ void MuxManager::initialize()
     }
 
     mDbInterfacePtr->initialize();
+
+    mMuxConfig.enableSwitchoverMeasurement(enable_feature_measurement);
 }
 
 //

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -179,9 +179,11 @@ public:
     *
     *@brief initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db
     *
-    *@return none
+    * @param enable_feature_measurement (in) whether the feature that decreases link prober interval is enabled or not 
+    * 
+    * @return none
     */
-    void initialize();
+    void initialize(bool enable_feature_measurement);
 
     /**
     *@method deinitialize

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -276,6 +276,26 @@ public:
     */
     inline uint32_t getDecreasedTimeoutIpv4_msec() const {return mDecreasedTimeoutIpv4_msec;};
 
+    /**
+     * @method getIfEnableSwitchoverMeasurement
+     * 
+     * @brief check if the feature that decreases link prober interval to measure switch overhead is enabled or not 
+     * 
+     * @return if switch overhead measurement feature is enabled
+     */
+    inline bool getIfEnableSwitchoverMeasurement() {return mEnableSwitchoverMeasurement;};
+
+    /**
+     * enableSwitchoverMeasurement
+     * 
+     * @brief enable or disable the feature that decreases link prober interval to measure switch overhead
+     * 
+     * @param enable_feature (in) enable feature 
+     * 
+     * @return  none
+     */
+    inline void enableSwitchoverMeasurement(bool enable_feature) {mEnableSwitchoverMeasurement = enable_feature;};
+
 private:
     uint8_t mNumberOfThreads = 5;
     uint32_t mTimeoutIpv4_msec = 100;
@@ -286,6 +306,7 @@ private:
     uint32_t mMuxStateChangeRetryCount = 1;
     uint32_t mLinkStateChangeRetryCount = 1;
 
+    bool mEnableSwitchoverMeasurement = false;
     uint32_t mDecreasedTimeoutIpv4_msec = 10;
 
     std::array<uint8_t, ETHER_ADDR_LEN> mTorMacAddress;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -267,7 +267,7 @@ public:
      * 
      * @return if switch overhead measurement feature is enabled
      */
-    inline bool ifEnableSwitchoverMeasurement() {return mEnableSwitchoverMeasurement;};
+    inline bool ifEnableSwitchoverMeasurement() {return mMuxConfig.getIfEnableSwitchoverMeasurement();};
 
 private:
     MuxConfig &mMuxConfig;
@@ -277,7 +277,6 @@ private:
     uint16_t mServerId;
     Mode mMode = Manual;
 
-    bool mEnableSwitchoverMeasurement = false;
 };
 
 } /* namespace common */

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1130,4 +1130,33 @@ TEST_F(LinkManagerStateMachineTest, PostPckLossUpdateAndResetEvent)
     EXPECT_EQ(mDbInterfacePtr->mExpectedPacketCount, 0);    
 }
 
+TEST_F(LinkManagerStateMachineTest, EnableDecreaseLinkProberIntervalFeature)
+{
+    setMuxStandby();
+    
+    // feature is disabled by default 
+    EXPECT_FALSE(mMuxConfig.getIfEnableSwitchoverMeasurement());
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mDecreaseIntervalCallCount, 0);
+
+    // switch to active 
+    handleMuxConfig("active", 4);
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Active, Up); 
+
+    // interval is not decreased   
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mDecreaseIntervalCallCount, 0);
+
+    // enable the feature 
+    mMuxConfig.enableSwitchoverMeasurement(true);
+    EXPECT_TRUE(mMuxConfig.getIfEnableSwitchoverMeasurement());
+
+    // switch to standby (fake inconsistency between state db and mux probing)
+    handleProbeMuxState("standby", 3);
+    handleGetMuxState("active", 3);
+
+    // interval is decreased once 
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mDecreaseIntervalCallCount, 1);
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Can't cleanly `cherry-pick` the commit below: 

48abc9e Jing Zhang      Thu Apr 14 16:50:04 2022 -0700  Add support to enable switchover time measurement (with link prober interval decreased to 10ms) feature  (#61)

Summary:
Fixes # (issue)
Add support to enable/disable the feature that decreases link prober interval. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To have the option to enable this feature. 

#### How did you do it?
Add options `--measure_switchover_overhead` , `-m` to linkmgrd process. 

#### How did you verify/test it?
1. Tested on dual testbed.
2. Passed all `dualtor_io` tests. Failed `dualtor/test_tunnel_memory_leak.py::test_tunnel_memory_leak` but noticed the same test failed on version .62. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->