### PR TITLE
[202012] Avoid proactively switching to active if default route is missing

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -257,13 +257,18 @@ void MuxPort::handleMuxConfig(const std::string &config)
 //
 void MuxPort::handleDefaultRouteState(const std::string &routeState)
 {
-    MUXLOGDEBUG(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+    MUXLOGWARNING(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
+
+    link_manager::LinkManagerStateMachine::DefaultRoute state = link_manager::LinkManagerStateMachine::DefaultRoute::OK;
+    if (routeState == "na") {
+        state = link_manager::LinkManagerStateMachine::DefaultRoute::NA;
+    }
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
         &link_manager::LinkManagerStateMachine::handleDefaultRouteStateNotification,
         &mLinkManagerStateMachine,
-        routeState
+        state
     )));
 }
 

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -110,6 +110,19 @@ public:
     };
 
     /**
+     * @enum DefaultRoute 
+     * 
+     * @brief labels corresponding to each ToR default states
+     */
+    enum class DefaultRoute {
+        Wait,
+        NA,
+        OK,
+
+        Count
+    };
+
+    /**
      *@enum Metrics
      *
      *@brief Metrics Data to be written to MUX_METRICS state db table
@@ -498,7 +511,7 @@ public:
     void handleSwitchActiveRequestEvent();
 
     /**
-     * @method handleDefaultRouteStateNotification(const std::string &routeState)
+     * @method handleDefaultRouteStateNotification(const DefaultRoute routeState)
      * 
      * @brief handle default route state notification from routeorch
      * 
@@ -506,7 +519,7 @@ public:
      * 
      * @return none
     */
-    void handleDefaultRouteStateNotification(const std::string &routeState);
+    void handleDefaultRouteStateNotification(const DefaultRoute routeState);
 
     /**
      * @method shutdownOrRestartLinkProberOnDefaultRoute()
@@ -1046,7 +1059,7 @@ private:
 
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
-    std::string mDefaultRouteState = "na";
+    DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
 
     std::bitset<ComponentCount> mComponentInitState = {0};
     Label mLabel = Label::Uninitialized;

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -187,6 +187,7 @@ void LinkManagerStateMachineTest::handleMuxConfig(std::string config, uint32_t c
 void LinkManagerStateMachineTest::activateStateMachine()
 {
     mFakeMuxPort.activateStateMachine();
+    mFakeMuxPort.handleDefaultRouteState("ok");
 }
 
 void LinkManagerStateMachineTest::setMuxActive()
@@ -1060,17 +1061,13 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
     setMuxActive();
 
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
+
     postDefaultRouteEvent("na", 3);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
-}
 
-TEST_F(LinkManagerStateMachineTest, MuxStandbyDefaultRouteStateOK) 
-{
-    setMuxStandby();
-
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,0);
     postDefaultRouteEvent("ok", 3);
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,2);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
Can't cleanly `cherry-pick`  the commit below:
c4858a6 Jing Zhang      Thu Apr 14 11:27:55 2022 -0700  Avoid proactively switching to `active` if default route is missing  (#62)

Summary:
Fixes # (issue)

This PR is to avoid proactively switch to `active` if default route is missing. 

By proactively switching, it means:
* switches triggered by peer HB missing
* switches triggered by peer link state down 

sign-off: Jing Zhang zhangjing@microsoft.com  

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
ToR missing default route can't be `active healthy`. Toggling to active at this moment will only cause unwanted packet loss. 

#### How did you do it?
Avoid the switch. 

#### How did you verify/test it?
Passed all sonic-mgmt `dualtor_io` tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->