### PR TITLE
lower log level to warning

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1283,7 +1283,7 @@ void ActiveStandbyStateMachine::LinkProberWaitMuxStandbyLinkUpTransitionFunction
 //
 void ActiveStandbyStateMachine::LinkProberWaitMuxUnknownLinkUpTransitionFunction(CompositeState &nextState)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(mMuxPortConfig.getPortName());
 
     startMuxProbeTimer(mMuxUnknownBackoffFactor);
     mMuxUnknownBackoffFactor <<= 1;
@@ -1321,7 +1321,7 @@ void ActiveStandbyStateMachine::LinkProberUnknownMuxStandbyLinkDownTransitionFun
 //
 void ActiveStandbyStateMachine::LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(mMuxPortConfig.getPortName());
 
     startMuxProbeTimer(mMuxUnknownBackoffFactor);
     mMuxUnknownBackoffFactor <<= 1;
@@ -1359,7 +1359,7 @@ void ActiveStandbyStateMachine::LinkProberWaitMuxStandbyLinkDownTransitionFuncti
 //
 void ActiveStandbyStateMachine::LinkProberWaitMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(mMuxPortConfig.getPortName());
 
     startMuxProbeTimer(mMuxUnknownBackoffFactor);
     mMuxUnknownBackoffFactor <<= 1;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to lower `MuxUnknown` state transition handler logs to `WARNING` level. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
It's causing noise for `LogAnalyzer`. 

#### How did you do it?
Lower the log level from `ERROR` to `WARNING`. 

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->