### PR TITLE
Reset `WaitActiveUp` count before switching to `active`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -333,6 +333,13 @@ void ActiveStandbyStateMachine::switchMuxState(
             mMuxPortConfig.getPortName() %
             mMuxStateName[label]
         );
+
+        // mWaitActiveUpCount is introduced to address asymmetric link drop issue. 
+        // Resetting the count to avoid unnecessary HB suspends. 
+        if(label == mux_state::MuxState::Label::Active) {
+            mWaitActiveUpCount = 0;
+        }
+
         enterMuxState(nextState, mux_state::MuxState::Label::Wait);
         mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
         mMuxPortPtr->postMetricsEvent(Metrics::SwitchingStart, label);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

`mWaitActiveUpCount` was introduced to handle active side asymmetric link drop issue (**internal repo PR 4318425**). It helps standby ToR take over when active ToR is dropping northbound packets only. 

But in scenarios when switching to active, it's also possible that mux state notification arrives before link prober active events, hence enters `LinkProberWaitMuxActiveLinkUp` composite state. If we don't reset the count, it can lead to unnecessary heartbeat suspending. 

This issue was the root cause for credo cable 400+ ms packet loss issue. 
 
sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid unnecessary heartbeat suspends. 

#### How did you do it?
Reset composite state count.

#### How did you verify/test it?
Run the 2000-toggle experiment again, can't reproduce the 400+ ms HB loss issue any more. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->