### PR TITLE
[202012] Add option to enable or disable default route related feature 

### DIFF
--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -65,6 +65,7 @@ int main(int argc, const char* argv[])
     //
     boost::log::trivial::severity_level level;
     bool measureSwitchover = false;
+    bool defaultRoute = false;
 
     program_options::options_description description("linkmgrd options");
     description.add_options()
@@ -77,6 +78,10 @@ int main(int argc, const char* argv[])
          ("measure_switchover_overhead,m",
          program_options::bool_switch(&measureSwitchover)->default_value(false),
          "Decrease link prober interval after switchover to better measure switchover overhead")
+         ("default_route,d",
+         program_options::bool_switch(&defaultRoute)->default_value(false),
+         "Disable heartbeat sending and avoid switching to active when default route is missing"
+         )
     ;
 
     //
@@ -115,7 +120,7 @@ int main(int argc, const char* argv[])
         link_manager::LinkManagerStateMachine::initializeTransitionFunctionTable();
 
         std::shared_ptr<mux::MuxManager> muxManagerPtr = std::make_shared<mux::MuxManager> ();
-        muxManagerPtr->initialize(measureSwitchover);
+        muxManagerPtr->initialize(measureSwitchover, defaultRoute);
         muxManagerPtr->run();
         muxManagerPtr->deinitialize();
     }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -290,7 +290,7 @@ void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &rou
     while (portMapIterator != mPortMap.end()) {
         portMapIterator->second->handleDefaultRouteState(nextState);
         portMapIterator ++;
-    }                                                                                                                               
+    }
 }
 
 //

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -59,7 +59,7 @@ MuxManager::MuxManager() :
 //
 // initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db
 //
-void MuxManager::initialize(bool enable_feature_measurement)
+void MuxManager::initialize(bool enable_feature_measurement, bool enable_feature_default_route)
 {
     for (uint8_t i = 0; (mMuxConfig.getNumberOfThreads() > 2) &&
                         (i < mMuxConfig.getNumberOfThreads() - 2); i++) {
@@ -71,6 +71,7 @@ void MuxManager::initialize(bool enable_feature_measurement)
     mDbInterfacePtr->initialize();
 
     mMuxConfig.enableSwitchoverMeasurement(enable_feature_measurement);
+    mMuxConfig.enableDefaultRouteFeature(enable_feature_default_route);
 }
 
 //
@@ -289,7 +290,7 @@ void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &rou
     while (portMapIterator != mPortMap.end()) {
         portMapIterator->second->handleDefaultRouteState(nextState);
         portMapIterator ++;
-    }
+    }                                                                                                                               
 }
 
 //

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -180,10 +180,11 @@ public:
     *@brief initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db
     *
     * @param enable_feature_measurement (in) whether the feature that decreases link prober interval is enabled or not 
+    * @param enable_feature_default_route (in) whether the feature that shutdowns link prober & avoid switching active when defaul route is missing, is enable or not
     * 
     * @return none
     */
-    void initialize(bool enable_feature_measurement);
+    void initialize(bool enable_feature_measurement, bool enable_feature_default_route);
 
     /**
     *@method deinitialize

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -260,7 +260,7 @@ void MuxPort::handleDefaultRouteState(const std::string &routeState)
     MUXLOGWARNING(boost::format("port: %s, state db default route state: %s") % mMuxPortConfig.getPortName() % routeState);
 
     link_manager::LinkManagerStateMachine::DefaultRoute state = link_manager::LinkManagerStateMachine::DefaultRoute::OK;
-    if (routeState == "na") {
+    if (routeState == "na" && mMuxPortConfig.ifEnableDefaultRouteFeature()) {
         state = link_manager::LinkManagerStateMachine::DefaultRoute::NA;
     }
 

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -296,6 +296,26 @@ public:
      */
     inline void enableSwitchoverMeasurement(bool enable_feature) {mEnableSwitchoverMeasurement = enable_feature;};
 
+    /**
+     * @method enableDefaultRouteFeature
+     * 
+     * @brief enable or disable the feature that shutdowns link prober & avoid switching active when defaul route is missing
+     * 
+     * @param enable_feature (in) enable feature
+     * 
+     * @return none 
+     */
+    inline void enableDefaultRouteFeature(bool enable_feature) {mEnableDefaultRouteFeature = enable_feature;};
+
+    /**
+     * @method getIfEnableDefaultRouteFeature
+     * 
+     * @brief check if default route related feature is enabled or not 
+     * 
+     * @return if default route related feature is enabled or not
+     */
+    inline bool getIfEnableDefaultRouteFeature() {return mEnableDefaultRouteFeature;};
+
 private:
     uint8_t mNumberOfThreads = 5;
     uint32_t mTimeoutIpv4_msec = 100;
@@ -308,6 +328,8 @@ private:
 
     bool mEnableSwitchoverMeasurement = false;
     uint32_t mDecreasedTimeoutIpv4_msec = 10;
+
+    bool mEnableDefaultRouteFeature = false;
 
     std::array<uint8_t, ETHER_ADDR_LEN> mTorMacAddress;
     boost::asio::ip::address mLoopbackIpv4Address = boost::asio::ip::make_address("10.212.64.0");

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -269,6 +269,15 @@ public:
      */
     inline bool ifEnableSwitchoverMeasurement() {return mMuxConfig.getIfEnableSwitchoverMeasurement();};
 
+    /**
+     * @method ifEnableDefaultRouteFeature
+     * 
+     * @brief check if the default route related feature is enabled or not 
+     * 
+     * @return if the feature is enabled
+     */
+    inline bool ifEnableDefaultRouteFeature() {return mMuxConfig.getIfEnableDefaultRouteFeature();};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1060,14 +1060,22 @@ TEST_F(LinkManagerStateMachineTest, MuxActivDefaultRouteStateNA)
 {
     setMuxActive();
 
+    EXPECT_FALSE(mMuxConfig.getIfEnableDefaultRouteFeature());
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,1);
 
     postDefaultRouteEvent("na", 3);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,2);
+
+    mMuxConfig.enableDefaultRouteFeature(true);
+    postDefaultRouteEvent("na", 3);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,2);
 
     postDefaultRouteEvent("ok", 3);
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,2);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount,1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount,3);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->

Can't cleanly `cherry-pick` commit below: 
7bb06fb Jing Zhang      Tue May 3 09:48:28 2022 -0700   Add Cli support to enable or disable default route related feature (#68)

### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Add command line option `--default_route, -d` to enable or disable default route related feature. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
In some scenarios, users might not care if default route is missing. This PR provides options for users to disable default route related feature. 

#### How did you do it?
Add support for cli option. 

#### How did you verify/test it?
Tested on dual testbed. LinkProber is shutdown only when the feature is enabled. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->