### PR TITLE
Support switch between using wellknown mac or server mac addr 

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -814,6 +814,8 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                         mMuxManagerPtr->setNegativeStateChangeRetryCount(boost::lexical_cast<uint32_t> (v));
                     } else if (f == "suspend_timer") {
                         mMuxManagerPtr->setSuspendTimeout_msec(boost::lexical_cast<uint32_t> (v));
+                    } else if (f == "use_known_mac") {
+                        mMuxManagerPtr->setUseKnownMacActiveActive(v == "enable");
                     }
 
                     MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -814,8 +814,8 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                         mMuxManagerPtr->setNegativeStateChangeRetryCount(boost::lexical_cast<uint32_t> (v));
                     } else if (f == "suspend_timer") {
                         mMuxManagerPtr->setSuspendTimeout_msec(boost::lexical_cast<uint32_t> (v));
-                    } else if (f == "use_known_mac") {
-                        mMuxManagerPtr->setUseKnownMacActiveActive(v == "enable");
+                    } else if (f == "use_well_known_mac") {
+                        mMuxManagerPtr->setUseWellKnownMacActiveActive(v == "enable");
                     }
 
                     MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -357,7 +357,7 @@ void MuxManager::addOrUpdateDefaultRouteState(bool is_v4, const std::string &rou
     while (portMapIterator != mPortMap.end()) {
         portMapIterator->second->handleDefaultRouteState(nextState);
         portMapIterator ++;
-    }                                                                                                                               
+    }
 }
 
 //

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -55,16 +55,16 @@ MuxManager::MuxManager() :
 }
 
 //
-// ---> setUseKnownMacActiveActive(bool useKnownMac);
+// ---> setUseWellKnownMacActiveActive(bool UseWellKnownMac);
 //
 //  set to use known mac for all ports in active-active cable type
 //
-void MuxManager::setUseKnownMacActiveActive(bool useKnownMac)
+void MuxManager::setUseWellKnownMacActiveActive(bool useWellKnownMac)
 {
-    mMuxConfig.setUseKnownMacActiveActive(useKnownMac);
+    mMuxConfig.setUseWellKnownMacActiveActive(useWellKnownMac);
 
     for (const auto & [portName, muxPort] : mPortMap) {
-        muxPort->handleUseKnownMacAddress();
+        muxPort->handleUseWellKnownMacAddress();
     }
 }
 
@@ -414,8 +414,8 @@ std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &por
             if (muxPortCableType == common::MuxPortConfig::PortCableType::ActiveActive) {
                 std::array<uint8_t, ETHER_ADDR_LEN> address;
                 generateServerMac(serverId, address);
-                muxPortPtr->setKnownMacAddress(address);
-                if (mMuxConfig.getIfUseKnownMacActiveActive()) {
+                muxPortPtr->setWellKnownMacAddress(address);
+                if (mMuxConfig.getIfUseWellKnownMacActiveActive()) {
                     muxPortPtr->setServerMacAddress(address);
                 }
             }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -55,6 +55,21 @@ MuxManager::MuxManager() :
 }
 
 //
+// ---> setUseKnownMacActiveActive(bool useKnownMac);
+//
+//  set to use known mac for all ports in active-active cable type
+//
+void MuxManager::setUseKnownMacActiveActive(bool useKnownMac)
+{
+    mMuxConfig.setUseKnownMacActiveActive(useKnownMac);
+
+    for (const auto & [portName, muxPort] : mPortMap) {
+        muxPort->handleUseKnownMacAddress();
+    }
+}
+
+
+//
 // ---> initialize();
 //
 // initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db
@@ -399,7 +414,10 @@ std::shared_ptr<MuxPort> MuxManager::getMuxPortPtrOrThrow(const std::string &por
             if (muxPortCableType == common::MuxPortConfig::PortCableType::ActiveActive) {
                 std::array<uint8_t, ETHER_ADDR_LEN> address;
                 generateServerMac(serverId, address);
-                muxPortPtr->setServerMacAddress(address);
+                muxPortPtr->setKnownMacAddress(address);
+                if (mMuxConfig.getIfUseKnownMacActiveActive()) {
+                    muxPortPtr->setServerMacAddress(address);
+                }
             }
             mPortMap.insert({portName, muxPortPtr});
         }

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -181,6 +181,18 @@ public:
     */
     inline void setLoopbackIpv4Address(boost::asio::ip::address& address) {mMuxConfig.setLoopbackIpv4Address(address);};
 
+
+    /**
+    *@method setUseKnownMacActiveActive
+    *
+    *@brief setter to set if use known mac to probe for active-active ports
+    *
+    *@param useKnownMac (in)  true to use known mac to probe
+    *
+    *@return none
+    */
+    inline void setUseKnownMacActiveActive(bool useKnownMac) { mMuxConfig.setUseKnownMacActiveActive(useKnownMac); };
+
     /**
     *@method initialize
     *

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -183,15 +183,15 @@ public:
 
 
     /**
-    *@method setUseKnownMacActiveActive
+    *@method setUseWellKnownMacActiveActive
     *
-    *@brief setter to set if use known mac to probe for active-active ports
+    *@brief setter to set if use well known mac to probe for active-active ports
     *
-    *@param useKnownMac (in)  true to use known mac to probe
+    *@param useWellKnownMac (in)  true to use known mac to probe
     *
     *@return none
     */
-    void setUseKnownMacActiveActive(bool useKnownMac);
+    void setUseWellKnownMacActiveActive(bool useWellKnownMac);
 
     /**
     *@method initialize

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -191,7 +191,7 @@ public:
     *
     *@return none
     */
-    inline void setUseKnownMacActiveActive(bool useKnownMac) { mMuxConfig.setUseKnownMacActiveActive(useKnownMac); };
+    void setUseKnownMacActiveActive(bool useKnownMac);
 
     /**
     *@method initialize

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -183,6 +183,22 @@ void MuxPort::handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN
 }
 
 //
+// ---> handleUseKnownMacAddress()
+//
+// handles use known mac
+//
+void MuxPort::handleUseKnownMacAddress()
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handleUseKnownMacAddressNotification,
+        mLinkManagerStateMachinePtr.get()
+    )));
+}
+
+//
 // ---> handleGetMuxState(const std::string &muxState);
 //
 // handles MUX state updates

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -183,17 +183,17 @@ void MuxPort::handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN
 }
 
 //
-// ---> handleUseKnownMacAddress()
+// ---> handleUseWellKnownMacAddress()
 //
-// handles use known mac
+// handles use well known mac
 //
-void MuxPort::handleUseKnownMacAddress()
+void MuxPort::handleUseWellKnownMacAddress()
 {
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachineBase::handleUseKnownMacAddressNotification,
+        &link_manager::LinkManagerStateMachineBase::handleUseWellKnownMacAddressNotification,
         mLinkManagerStateMachinePtr.get()
     )));
 }

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -227,15 +227,15 @@ public:
     inline void setServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setBladeMacAddress(address);};
 
     /**
-    *@method setKnownMacAddress
+    *@method setWellKnownMacAddress
     *
-    *@brief setter for server known MAC address
+    *@brief setter for server well known MAC address
     *
-    *@param address (in) server known MAC address
+    *@param address (in) server well known MAC address
     *
     *@return none
     */
-    inline void setKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setKnownMacAddress(address);};
+    inline void setWellKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setWellKnownMacAddress(address);};
 
     /**
     *@method handleBladeIpv4AddressUpdate
@@ -293,13 +293,13 @@ public:
     void handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address);
 
     /**
-    *@method handleUseKnownMacAddress
+    *@method handleUseWellKnownMacAddress
     *
-    *@brief handles use known MAC address
+    *@brief handles use well known MAC address
     *
     *@return none
     */
-    void handleUseKnownMacAddress();
+    void handleUseWellKnownMacAddress();
 
     /**
     *@method handleGetMuxState

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -227,6 +227,17 @@ public:
     inline void setServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setBladeMacAddress(address);};
 
     /**
+    *@method setKnownMacAddress
+    *
+    *@brief setter for server known MAC address
+    *
+    *@param address (in) server known MAC address
+    *
+    *@return none
+    */
+    inline void setKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mMuxPortConfig.setKnownMacAddress(address);};
+
+    /**
     *@method handleBladeIpv4AddressUpdate
     *
     *@brief update server/blade IPv4 Address
@@ -280,6 +291,15 @@ public:
     *@return none
     */
     void handleGetServerMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address);
+
+    /**
+    *@method handleUseKnownMacAddress
+    *
+    *@brief handles use known MAC address
+    *
+    *@return none
+    */
+    void handleUseKnownMacAddress();
 
     /**
     *@method handleGetMuxState

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -317,22 +317,22 @@ public:
     inline bool getIfEnableDefaultRouteFeature() {return mEnableDefaultRouteFeature;};
 
     /**
-     * @method getIfUseKnownMacActiveActive
+     * @method getIfUseWellKnownMacActiveActive
      * 
-     * @brief check if use known mac to probe for active-active ports
+     * @brief check if use well known mac to probe for active-active ports
      * 
-     * @return true to use known mac to probe for active-active ports
+     * @return true to use well known mac to probe for active-active ports
      */
-    inline bool getIfUseKnownMacActiveActive() { return mUseKnownMacActiveActive; };
+    inline bool getIfUseWellKnownMacActiveActive() { return mUseWellKnownMacActiveActive; };
 
     /**
-     * @method setUseKnownMacActiveActive
+     * @method setUseWellKnownMacActiveActive
      * 
-     * @brief setter to set if use known mac to probe for active-active ports
+     * @brief setter to set if use well known mac to probe for active-active ports
      * 
      * @return none
      */
-    inline void setUseKnownMacActiveActive(bool useKnownMacActiveActive) { mUseKnownMacActiveActive = useKnownMacActiveActive; };
+    inline void setUseWellKnownMacActiveActive(bool useWellKnownMacActiveActive) { mUseWellKnownMacActiveActive = useWellKnownMacActiveActive; };
 
 private:
     uint8_t mNumberOfThreads = 5;
@@ -348,7 +348,7 @@ private:
     uint32_t mDecreasedTimeoutIpv4_msec = 10;
 
     bool mEnableDefaultRouteFeature = false;
-    bool mUseKnownMacActiveActive = true;
+    bool mUseWellKnownMacActiveActive = true;
 
     std::array<uint8_t, ETHER_ADDR_LEN> mTorMacAddress;
     boost::asio::ip::address mLoopbackIpv4Address = boost::asio::ip::make_address("10.212.64.0");

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -317,13 +317,13 @@ public:
     inline bool getIfEnableDefaultRouteFeature() {return mEnableDefaultRouteFeature;};
 
     /**
-     * @method getUseKnownMacActiveActive
+     * @method getIfUseKnownMacActiveActive
      * 
      * @brief check if use known mac to probe for active-active ports
      * 
      * @return true to use known mac to probe for active-active ports
      */
-    inline bool getUseKnownMacActiveActive() { return mUseKnownMacActiveActive; };
+    inline bool getIfUseKnownMacActiveActive() { return mUseKnownMacActiveActive; };
 
     /**
      * @method setUseKnownMacActiveActive

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -316,6 +316,24 @@ public:
      */
     inline bool getIfEnableDefaultRouteFeature() {return mEnableDefaultRouteFeature;};
 
+    /**
+     * @method getUseKnownMacActiveActive
+     * 
+     * @brief check if use known mac to probe for active-active ports
+     * 
+     * @return true to use known mac to probe for active-active ports
+     */
+    inline bool getUseKnownMacActiveActive() { return mUseKnownMacActiveActive; };
+
+    /**
+     * @method setUseKnownMacActiveActive
+     * 
+     * @brief setter to set if use known mac to probe for active-active ports
+     * 
+     * @return none
+     */
+    inline void setUseKnownMacActiveActive(bool useKnownMacActiveActive) { mUseKnownMacActiveActive = useKnownMacActiveActive; };
+
 private:
     uint8_t mNumberOfThreads = 5;
     uint32_t mTimeoutIpv4_msec = 100;
@@ -330,6 +348,7 @@ private:
     uint32_t mDecreasedTimeoutIpv4_msec = 10;
 
     bool mEnableDefaultRouteFeature = false;
+    bool mUseKnownMacActiveActive = true;
 
     std::array<uint8_t, ETHER_ADDR_LEN> mTorMacAddress;
     boost::asio::ip::address mLoopbackIpv4Address = boost::asio::ip::make_address("10.212.64.0");

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -310,6 +310,15 @@ public:
      */
     inline bool ifEnableDefaultRouteFeature() {return mMuxConfig.getIfEnableDefaultRouteFeature();};
 
+    /**
+     * @method getUseKnownMacActiveActive
+     * 
+     * @brief check if use known mac to probe for active-active ports
+     * 
+     * @return true to use known mac to probe for active-active ports
+     */
+    inline bool getUseKnownMacActiveActive() { return mMuxConfig.getUseKnownMacActiveActive(); }
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -311,19 +311,61 @@ public:
     inline bool ifEnableDefaultRouteFeature() {return mMuxConfig.getIfEnableDefaultRouteFeature();};
 
     /**
-     * @method getUseKnownMacActiveActive
+     * @method getIfUseKnownMacActiveActive
      * 
      * @brief check if use known mac to probe for active-active ports
      * 
      * @return true to use known mac to probe for active-active ports
      */
-    inline bool getUseKnownMacActiveActive() { return mMuxConfig.getUseKnownMacActiveActive(); }
+    inline bool getIfUseKnownMacActiveActive() { return mMuxConfig.getIfUseKnownMacActiveActive(); }
+
+    /**
+    *@method getKnownMacAddress
+    *
+    *@brief getter for server known MAC address
+    *
+    *@return MAC address
+    */
+    inline const std::array<uint8_t, ETHER_ADDR_LEN>& getKnownMacAddress() const {return mKnownMacAddress;};
+
+    /**
+    *@method setKnownMacAddress
+    *
+    *@brief setter for server known MAC address
+    *
+    *@param address (in) server known MAC address
+    *
+    *@return none
+    */
+    inline void setKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mKnownMacAddress = address;};
+
+    /**
+    *@method getLastUpdatedMacAddress
+    *
+    *@brief getter for last server MAC address update
+    *
+    *@return MAC address
+    */
+    inline const std::array<uint8_t, ETHER_ADDR_LEN>& getLastUpdatedMacAddress() const {return mLastUpdatedMacAddress;};
+
+    /**
+    *@method setLastUpdatedMacAddress
+    *
+    *@brief setter for last server MAC address update
+    *
+    *@param address (in) server known MAC address
+    *
+    *@return none
+    */
+    inline void setLastUpdatedMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mLastUpdatedMacAddress = address;};
 
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;
     boost::asio::ip::address mBladeIpv4Address;
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
+    std::array<uint8_t, ETHER_ADDR_LEN> mKnownMacAddress = {0, 0, 0, 0, 0, 0};
+    std::array<uint8_t, ETHER_ADDR_LEN> mLastUpdatedMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;
     PortCableType mPortCableType;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -311,33 +311,33 @@ public:
     inline bool ifEnableDefaultRouteFeature() {return mMuxConfig.getIfEnableDefaultRouteFeature();};
 
     /**
-     * @method getIfUseKnownMacActiveActive
+     * @method getIfUseWellKnownMacActiveActive
      * 
-     * @brief check if use known mac to probe for active-active ports
+     * @brief check if use well known mac to probe for active-active ports
      * 
-     * @return true to use known mac to probe for active-active ports
+     * @return true to use well known mac to probe for active-active ports
      */
-    inline bool getIfUseKnownMacActiveActive() { return mMuxConfig.getIfUseKnownMacActiveActive(); }
+    inline bool getIfUseWellKnownMacActiveActive() { return mMuxConfig.getIfUseWellKnownMacActiveActive(); }
 
     /**
-    *@method getKnownMacAddress
+    *@method getWellKnownMacAddress
     *
-    *@brief getter for server known MAC address
+    *@brief getter for server well known MAC address
     *
     *@return MAC address
     */
-    inline const std::array<uint8_t, ETHER_ADDR_LEN>& getKnownMacAddress() const {return mKnownMacAddress;};
+    inline const std::array<uint8_t, ETHER_ADDR_LEN>& getWellKnownMacAddress() const {return mWellKnownMacAddress;};
 
     /**
-    *@method setKnownMacAddress
+    *@method setWellKnownMacAddress
     *
-    *@brief setter for server known MAC address
+    *@brief setter for server well known MAC address
     *
-    *@param address (in) server known MAC address
+    *@param address (in) server well known MAC address
     *
     *@return none
     */
-    inline void setKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mKnownMacAddress = address;};
+    inline void setWellKnownMacAddress(const std::array<uint8_t, ETHER_ADDR_LEN> &address) {mWellKnownMacAddress = address;};
 
     /**
     *@method getLastUpdatedMacAddress
@@ -364,7 +364,7 @@ private:
     std::string mPortName;
     boost::asio::ip::address mBladeIpv4Address;
     std::array<uint8_t, ETHER_ADDR_LEN> mBladeMacAddress = {0, 0, 0, 0, 0, 0};
-    std::array<uint8_t, ETHER_ADDR_LEN> mKnownMacAddress = {0, 0, 0, 0, 0, 0};
+    std::array<uint8_t, ETHER_ADDR_LEN> mWellKnownMacAddress = {0, 0, 0, 0, 0, 0};
     std::array<uint8_t, ETHER_ADDR_LEN> mLastUpdatedMacAddress = {0, 0, 0, 0, 0, 0};
     uint16_t mServerId;
     Mode mMode = Manual;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -292,7 +292,8 @@ void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
-    if (!mMuxPortConfig.getUseKnownMacActiveActive() && address != mMuxPortConfig.getBladeMacAddress()) {
+    mMuxPortConfig.setLastUpdatedMacAddress(address);
+    if (!mMuxPortConfig.getIfUseKnownMacActiveActive() && address != mMuxPortConfig.getBladeMacAddress()) {
         mMuxPortConfig.setBladeMacAddress(address);
         if (mUpdateEthernetFrameFnPtr) {
             mUpdateEthernetFrameFnPtr();
@@ -310,6 +311,41 @@ void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<
                 mComponentInitState.test(LinkProberComponent)
             );
         }
+    }
+}
+
+//
+// ---> handleUseKnownMacAddressNotification();
+//
+// handle get Server MAC address
+//
+void ActiveActiveStateMachine::handleUseKnownMacAddressNotification()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+
+    std::array<uint8_t, ETHER_ADDR_LEN> address;
+    if (mMuxPortConfig.getIfUseKnownMacActiveActive()) {
+        address = mMuxPortConfig.getKnownMacAddress();
+    } else {
+        address = mMuxPortConfig.getLastUpdatedMacAddress();
+    }
+    mMuxPortConfig.setBladeMacAddress(address);
+
+    if (mUpdateEthernetFrameFnPtr) {
+        mUpdateEthernetFrameFnPtr();
+    } else {
+        std::array<char, 3 *ETHER_ADDR_LEN> addressStr = {0};
+        snprintf(
+            addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",
+            address[0], address[1], address[2], address[3], address[4], address[5]
+        );
+
+        MUXLOGERROR(
+            boost::format("%s: failed to update Ethernet frame with mac '%s', link prober init state: %d") %
+            mMuxPortConfig.getPortName() %
+            addressStr.data() %
+            mComponentInitState.test(LinkProberComponent)
+        );
     }
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -283,6 +283,36 @@ void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxStat
     enterPeerMuxState(label);
 }
 
+//
+// ---> handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
+//
+// handle get Server MAC address
+//
+void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+
+    if (!mMuxPortConfig.getUseKnownMacActiveActive() && address != mMuxPortConfig.getBladeMacAddress()) {
+        mMuxPortConfig.setBladeMacAddress(address);
+        if (mUpdateEthernetFrameFnPtr) {
+            mUpdateEthernetFrameFnPtr();
+        } else {
+            std::array<char, 3 *ETHER_ADDR_LEN> addressStr = {0};
+            snprintf(
+                addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",
+                address[0], address[1], address[2], address[3], address[4], address[5]
+            );
+
+            MUXLOGERROR(
+                boost::format("%s: failed to update Ethernet frame with mac '%s', link prober init state: %d") %
+                mMuxPortConfig.getPortName() %
+                addressStr.data() %
+                mComponentInitState.test(LinkProberComponent)
+            );
+        }
+    }
+}
+
 /*--------------------------------------------------------------------------------------------------------------
 |  link prober event handlers
 ---------------------------------------------------------------------------------------------------------------*/

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -293,7 +293,7 @@ void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     mMuxPortConfig.setLastUpdatedMacAddress(address);
-    if (!mMuxPortConfig.getIfUseKnownMacActiveActive() && address != mMuxPortConfig.getBladeMacAddress()) {
+    if (!mMuxPortConfig.getIfUseWellKnownMacActiveActive() && address != mMuxPortConfig.getBladeMacAddress()) {
         mMuxPortConfig.setBladeMacAddress(address);
         if (mUpdateEthernetFrameFnPtr) {
             mUpdateEthernetFrameFnPtr();
@@ -315,17 +315,17 @@ void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<
 }
 
 //
-// ---> handleUseKnownMacAddressNotification();
+// ---> handleUseWellKnownMacAddressNotification();
 //
-// handle get Server MAC address
+// handle use well known mac address
 //
-void ActiveActiveStateMachine::handleUseKnownMacAddressNotification()
+void ActiveActiveStateMachine::handleUseWellKnownMacAddressNotification()
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     std::array<uint8_t, ETHER_ADDR_LEN> address;
-    if (mMuxPortConfig.getIfUseKnownMacActiveActive()) {
-        address = mMuxPortConfig.getKnownMacAddress();
+    if (mMuxPortConfig.getIfUseWellKnownMacActiveActive()) {
+        address = mMuxPortConfig.getWellKnownMacAddress();
     } else {
         address = mMuxPortConfig.getLastUpdatedMacAddress();
     }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -148,6 +148,17 @@ public: // db event handlers
      */
     void handlePeerMuxStateNotification(mux_state::MuxState::Label label) override;
 
+    /**
+     *@method handleGetServerMacNotification
+     *
+     *@brief handle get Server MAC address
+     *
+     *@param address (in)    Server MAC address
+     *
+     *@return none
+     */
+    void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address) override;
+
 public: // link prober event handlers
     /**
      * @method handleSuspendTimerExpiry

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -159,6 +159,15 @@ public: // db event handlers
      */
     void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address) override;
 
+    /**
+     *@method handleUseKnownMacAddressNotification
+     *
+     *@brief handle use known Server MAC address
+     *
+     *@return none
+     */
+    void handleUseKnownMacAddressNotification() override;
+
 public: // link prober event handlers
     /**
      * @method handleSuspendTimerExpiry

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -160,13 +160,13 @@ public: // db event handlers
     void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address) override;
 
     /**
-     *@method handleUseKnownMacAddressNotification
+     *@method handleUseWellKnownMacAddressNotification
      *
-     *@brief handle use known Server MAC address
+     *@brief handle use well known Server MAC address
      *
      *@return none
      */
-    void handleUseKnownMacAddressNotification() override;
+    void handleUseWellKnownMacAddressNotification() override;
 
 public: // link prober event handlers
     /**

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -140,11 +140,11 @@ void LinkManagerStateMachineBase::handleGetServerMacAddressNotification(std::arr
 }
 
 //
-// ---> handleUseKnownMacAddressNotification();
+// ---> handleUseWellKnownMacAddressNotification();
 //
-// handle use known Server MAC address
+// handle use well known Server MAC address
 //
-void LinkManagerStateMachineBase::handleUseKnownMacAddressNotification()
+void LinkManagerStateMachineBase::handleUseWellKnownMacAddressNotification()
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -140,6 +140,16 @@ void LinkManagerStateMachineBase::handleGetServerMacAddressNotification(std::arr
 }
 
 //
+// ---> handleUseKnownMacAddressNotification();
+//
+// handle use known Server MAC address
+//
+void LinkManagerStateMachineBase::handleUseKnownMacAddressNotification()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+//
 // ---> handleGetMuxStateNotification(mux_state::MuxState::Label label);
 //
 // handle get MUX state notification

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -306,13 +306,13 @@ public:
     virtual void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
 
     /**
-     *@method handleUseKnownMacAddressNotification
+     *@method handleUseWellKnownMacAddressNotification
      *
-     *@brief handle use known Server MAC address
+     *@brief handle use well known Server MAC address
      *
      *@return none
      */
-    virtual void handleUseKnownMacAddressNotification();
+    virtual void handleUseWellKnownMacAddressNotification();
 
     /**
      *@method handleGetMuxStateNotification

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -306,6 +306,15 @@ public:
     virtual void handleGetServerMacAddressNotification(std::array<uint8_t, ETHER_ADDR_LEN> address);
 
     /**
+     *@method handleUseKnownMacAddressNotification
+     *
+     *@brief handle use known Server MAC address
+     *
+     *@return none
+     */
+    virtual void handleUseKnownMacAddressNotification();
+
+    /**
      *@method handleGetMuxStateNotification
      *
      *@brief handle get MUX state notification

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -616,7 +616,7 @@ TEST_F(MuxManagerTest, LinkmgrdConfig)
     uint32_t positiveSignalCount = 2;
     uint32_t negativeSignalCount = 3;
     uint32_t suspendTimer = 5;
-    bool useWellKnownMac = false;
+    bool useWellKnownMac = true;
     std::deque<swss::KeyOpFieldsValuesTuple> entries = {
         {"LINK_PROBER", "SET", {{"interval_v4", boost::lexical_cast<std::string> (v4PorbeInterval)}}},
         {"LINK_PROBER", "SET", {{"interval_v6", boost::lexical_cast<std::string> (v6ProveInterval)}}},

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -101,11 +101,11 @@ uint32_t MuxManagerTest::getLinkWaitTimeout_msec(std::string port)
     return muxPortPtr->mMuxPortConfig.getLinkWaitTimeout_msec();
 }
 
-bool MuxManagerTest::getUseKnownMac(std::string port)
+bool MuxManagerTest::getIfUseKnownMac(std::string port)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
 
-    return muxPortPtr->mMuxPortConfig.getUseKnownMacActiveActive();
+    return muxPortPtr->mMuxPortConfig.getIfUseKnownMacActiveActive();
 }
 
 boost::asio::ip::address MuxManagerTest::getBladeIpv4Address(std::string port)
@@ -598,7 +598,7 @@ TEST_F(MuxManagerTest, LinkmgrdConfig)
     EXPECT_TRUE(getNegativeStateChangeRetryCount(port) == negativeSignalCount);
     EXPECT_TRUE(getLinkWaitTimeout_msec(port) == (negativeSignalCount + 1) * v4PorbeInterval);
     EXPECT_TRUE(common::MuxLogger::getInstance()->getLevel() == boost::log::trivial::warning);
-    EXPECT_TRUE(getUseKnownMac(port) == useKnownMac);
+    EXPECT_TRUE(getIfUseKnownMac(port) == useKnownMac);
 }
 
 TEST_P(MuxResponseTest, MuxResponse)

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -55,7 +55,7 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
-    bool getUseKnownMac(std::string port);
+    bool getIfUseKnownMac(std::string port);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -55,9 +55,11 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
-    bool getIfUseKnownMac(std::string port);
+    bool getIfUseWellKnownMac(std::string port);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
+    std::array<uint8_t, ETHER_ADDR_LEN> getLastUpdatedMacAddress(std::string port);
+    std::array<uint8_t, ETHER_ADDR_LEN> getWellKnownMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getTorMacAddress(std::string port);
     common::MuxPortConfig::PortCableType getPortCableType(const std::string &port);

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -55,6 +55,7 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
+    bool getUseKnownMac(std::string port);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Add a new field `use_known_mac` to table `LINK_PROBER`:
* if `use_known_mac` is `enable`, linkmgrd will use known mac to probe(default behavior)
* if `use_known_mac` is `disable`, linkmgrd will use server mac address from netlink

#### How did you do it?
Add a new boolean attribute `mUseKnownMacActiveActive` to `MuxConfig` to represent this switch.
If `mUseKnownMacActiveActive` is `false`, the state machine will respond to server mac change.
else, the state machine will not respond to server mac change.

#### How did you verify/test it?
Pass unit test

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->