### PR TITLE
Add support for reconciliation after warm restart 

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -826,8 +826,10 @@ void DbInterface::warmRestartReconciliation(const std::string &portName)
 {
     MUXLOGDEBUG(portName);
 
-    setMuxMode(portName, "auto");
-    mMuxManagerPtr->updateWarmRestartReconciliationCount(-1);
+    if (isWarmStart()) {
+        setMuxMode(portName, "auto");
+        mMuxManagerPtr->updateWarmRestartReconciliationCount(-1);
+    }
 }
 
 //

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -34,6 +34,7 @@
 #include "swss/dbconnector.h"
 #include "swss/producerstatetable.h"
 #include "swss/subscriberstatetable.h"
+#include "swss/warm_restart.h"
 
 #include "link_manager/LinkManagerStateMachineActiveStandby.h"
 #include "mux_state/MuxState.h"
@@ -295,7 +296,34 @@ public:
      * 
      * @return none
      */
-    virtual void warmRestartReconciliation(const std::string &portName);
+    void warmRestartReconciliation(const std::string &portName);
+
+    /**
+     * @method isWarmStart
+     * 
+     * @brief is warm start or not
+     * 
+     * @return system flag for warm start context 
+     */
+    virtual bool isWarmStart(){return swss::WarmStart::isWarmStart();};
+
+    /**
+     * @method getWarmStartTimer
+     * 
+     * @brief get warm start time out in sec
+     * 
+     * @return timeout in sec 
+     */
+    virtual uint32_t getWarmStartTimer(){return swss::WarmStart::getWarmStartTimer("linkmgrd", "mux");};
+
+    /**
+     * @method setWarmStartStateReconciled
+     * 
+     * @brief set warm start state reconciled
+     * 
+     * @return none
+     */
+    virtual void setWarmStartStateReconciled(){swss::WarmStart::setWarmStartState("linkmgrd", swss::WarmStart::RECONCILED);};
 
 private:
     friend class test::MuxManagerTest;

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -274,6 +274,29 @@ public:
     */
     void stopSwssNotificationPoll() {mPollSwssNotifcation = false;};
 
+    /**
+     * @method setMuxMode 
+     * 
+     * @brief set config db mux mode 
+     * 
+     * @param portName (in) MUX port name 
+     * @param state (in) MUX mode state 
+     *  
+     * @return none
+     */
+    void setMuxMode(const std::string &portName, const std::string state);
+
+    /**
+     * @method warmRestartReconciliation
+     * 
+     * @brief port warm restart reconciliation procedure
+     * 
+     * @param portName(in) Mux port name
+     * 
+     * @return none
+     */
+    virtual void warmRestartReconciliation(const std::string &portName);
+
 private:
     friend class test::MuxManagerTest;
 
@@ -398,6 +421,18 @@ private:
         const uint64_t unknownEventCount, 
         const uint64_t expectedPacketCount
     );
+
+    /**
+     * @method handleSetMuxMode
+     * 
+     * @brief handle set mux mode 
+     * 
+     * @param portName (in) MUX port name
+     * @param state (in) MUX mode state
+     * 
+     * @return none
+     */
+    virtual void handleSetMuxMode(const std::string &portName, const std::string state);
 
     /**
     *@method processTorMacAddress

--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -26,6 +26,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 
+#include "swss/warm_restart.h"
+
 #include "MuxManager.h"
 #include "MuxPort.h"
 #include "common/MuxConfig.h"
@@ -122,6 +124,13 @@ int main(int argc, const char* argv[])
 
         // initialize static data
         link_prober::IcmpPayload::generateGuid();
+
+        // warm restart static
+        swss::WarmStart::initialize("linkmgrd", "mux");
+        swss::WarmStart::checkWarmStart("linkmgrd", "mux");
+        if (swss::WarmStart::isWarmStart()) {
+            swss::WarmStart::setWarmStartState("linkmgrd", swss::WarmStart::INITIALIZED);
+        }
 
         std::shared_ptr<mux::MuxManager> muxManagerPtr = std::make_shared<mux::MuxManager> ();
         muxManagerPtr->initialize(measureSwitchover, defaultRoute);

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -28,8 +28,6 @@
 
 #include <boost/bind/bind.hpp>
 
-#include "swss/warm_restart.h"
-
 #include "common/MuxException.h"
 #include "common/MuxLogger.h"
 #include "MuxManager.h"
@@ -80,7 +78,6 @@ void MuxManager::setUseWellKnownMacActiveActive(bool useWellKnownMac)
 //
 void MuxManager::initialize(bool enable_feature_measurement, bool enable_feature_default_route)
 {
-
     for (uint8_t i = 0; (mMuxConfig.getNumberOfThreads() > 2) &&
                         (i < mMuxConfig.getNumberOfThreads() - 2); i++) {
         mThreadGroup.create_thread(
@@ -88,12 +85,12 @@ void MuxManager::initialize(bool enable_feature_measurement, bool enable_feature
         );
     }
 
-    if (swss::WarmStart::isWarmStart()) {
-        MUXLOGINFO("Detected warm restart context, starting reconciliation timer.");
-        startWarmRestartReconciliationTimer(swss::WarmStart::getWarmStartTimer("linkmgrd", "mux"));
-    }
-
     mDbInterfacePtr->initialize();
+
+    if (mDbInterfacePtr->isWarmStart()) {
+        MUXLOGINFO("Detected warm restart context, starting reconciliation timer.");
+        startWarmRestartReconciliationTimer(mDbInterfacePtr->getWarmStartTimer());
+    }
 
     mMuxConfig.enableSwitchoverMeasurement(enable_feature_measurement);
     mMuxConfig.enableDefaultRouteFeature(enable_feature_default_route);
@@ -575,7 +572,7 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
         MUXLOGWARNING("Reconciliation timed out after warm restart, set service to reconciled now.");
     }
 
-    swss::WarmStart::setWarmStartState("linkmgrd", swss::WarmStart::RECONCILED);
+    mDbInterfacePtr->setWarmStartStateReconciled();
 }
 
 } /* namespace mux */

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -441,6 +441,17 @@ public:
     */
     void addOrUpdateDefaultRouteState(bool is_v4, const std::string &routeState);
 
+    /**
+     * @method updateWarmRestartReconciliationCount
+     * 
+     * @brief update warm restart reconciliation count
+     * 
+     * @param increment
+     * 
+     * @return none
+     */
+    void updateWarmRestartReconciliationCount(int increment);
+
 private:
     /**
     *@method getMuxPortCableType
@@ -505,6 +516,38 @@ private:
     */
     void setDbInterfacePtr(std::shared_ptr<mux::DbInterface> dbInterfacePtr) {mDbInterfacePtr = dbInterfacePtr;};
 
+private: 
+    /**
+     * @method startWarmRestartReconciliationTimer
+     * 
+     * @brief start warm restart reconciliation timer
+     * 
+     * @return none
+     */
+    void startWarmRestartReconciliationTimer(uint32_t timeout=0);
+
+    /**
+     * @method handleWarmRestartReconciliationTimeout
+     * 
+     * @brief handle warm restart reconciliationTimeout
+     *
+     * @param errorCode (in) Boost error code 
+     *  
+     * @return none
+     */
+    void handleWarmRestartReconciliationTimeout(const boost::system::error_code errorCode);
+
+    /**
+     * @method handleUpdateReconciliationCount
+     * 
+     * @brief handler of updating reconciliation port count 
+     * 
+     * @param increment
+     * 
+     * @return none
+     */
+    void handleUpdateReconciliationCount(int increment);
+
 private:
     common::MuxConfig mMuxConfig;
 
@@ -512,6 +555,10 @@ private:
     boost::asio::io_service::work mWork;
     boost::thread_group mThreadGroup;
     boost::asio::signal_set mSignalSet;
+
+    boost::asio::io_service::strand mStrand;
+    boost::asio::deadline_timer mReconciliationTimer;
+    uint16_t mPortReconciliationCount = 0;
 
     std::shared_ptr<mux::DbInterface> mDbInterfacePtr;
 

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -36,8 +36,6 @@
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 
-#include "swss/warm_restart.h"
-
 #include "MuxPort.h"
 #include "common/MuxException.h"
 #include "common/MuxLogger.h"
@@ -414,7 +412,7 @@ void MuxPort::probeMuxState()
 //
 void MuxPort::warmRestartReconciliation()
 {
-    if (swss::WarmStart::isWarmStart() && mMuxPortConfig.getMode() != common::MuxPortConfig::Mode::Auto) {
+    if (mMuxPortConfig.getMode() != common::MuxPortConfig::Mode::Auto) {
         mDbInterfacePtr->warmRestartReconciliation(mMuxPortConfig.getPortName());
     }
 }

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -36,6 +36,8 @@
 #include <boost/random/uniform_int_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 
+#include "swss/warm_restart.h"
+
 #include "MuxPort.h"
 #include "common/MuxException.h"
 #include "common/MuxLogger.h"
@@ -402,6 +404,18 @@ void MuxPort::probeMuxState()
             break;
         default:
             break;
+    }
+}
+
+//
+// ---> warmRestartReconciliation();
+//
+// brief port warm restart reconciliation procedure
+//
+void MuxPort::warmRestartReconciliation()
+{
+    if (swss::WarmStart::isWarmStart() && mMuxPortConfig.getMode() != common::MuxPortConfig::Mode::Auto) {
+        mDbInterfacePtr->warmRestartReconciliation(mMuxPortConfig.getPortName());
     }
 }
 

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -386,6 +386,15 @@ public:
     */
     void resetPckLossCount();
 
+    /**
+     * @method warmRestartReconciliation
+     * 
+     * @brief port warm restart reconciliation procedure
+     * 
+     * @return none
+     */
+    void warmRestartReconciliation();
+
 protected:
     friend class test::MuxManagerTest;
     friend class test::FakeMuxPort;

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -374,6 +374,15 @@ public:
      */
     inline bool getIfEnableUseTorMac() {return mEnableUseTorMac;};
 
+    /**
+     * @method getMuxReconciliationTimeout
+     * 
+     * @brief getter of mux reconciliation time out 
+     * 
+     * @return timeout in sec
+     */
+    inline uint32_t getMuxReconciliationTimeout_sec(){return mMuxReconciliationTimeout_sec;};
+
 private:
     uint8_t mNumberOfThreads = 5;
     uint32_t mTimeoutIpv4_msec = 100;
@@ -386,6 +395,8 @@ private:
 
     bool mEnableSwitchoverMeasurement = false;
     uint32_t mDecreasedTimeoutIpv4_msec = 10;
+
+    uint32_t mMuxReconciliationTimeout_sec = 10;
 
     bool mEnableDefaultRouteFeature = false;
     bool mUseWellKnownMacActiveActive = true;

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -426,6 +426,8 @@ void ActiveStandbyStateMachine::activateStateMachine()
         mStartProbingFnPtr();
 
         updateMuxLinkmgrState();
+
+        mMuxPortPtr->warmRestartReconciliation();
     }
 }
 

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -97,4 +97,24 @@ void FakeDbInterface::postPckLossRatio(
     mExpectedPacketCount = expectedPacketCount;
 } 
 
+void FakeDbInterface::handleSetMuxMode(const std::string &portName, const std::string state)
+{
+    mSetMuxModeInvokeCount += 1;
+}
+
+bool FakeDbInterface::isWarmStart()
+{
+    return mWarmStartFlag;
+}
+
+uint32_t FakeDbInterface::getWarmStartTimer()
+{
+    return 0;
+}
+
+void FakeDbInterface::setWarmStartStateReconciled()
+{
+    mSetWarmStartStateReconciledInvokeCount++;
+}
+
 } /* namespace test */

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -59,10 +59,14 @@ public:
         const uint64_t unknownEventCount, 
         const uint64_t expectedPacketCount
     ) override;
-
+    virtual bool isWarmStart() override;
+    virtual uint32_t getWarmStartTimer() override;
+    virtual void setWarmStartStateReconciled() override; 
 
     void setNextMuxState(mux_state::MuxState::Label label) {mNextMuxState = label;};
 
+private:
+    virtual void handleSetMuxMode(const std::string &portName, const std::string state) override;
 
 public:
     mux_state::MuxState::Label mNextMuxState;
@@ -82,6 +86,9 @@ public:
     uint32_t mPostLinkProberMetricsInvokeCount = 0;
     uint64_t mUnknownEventCount = 0;
     uint64_t mExpectedPacketCount = 0;
+    uint32_t mSetMuxModeInvokeCount = 0;
+    uint32_t mSetWarmStartStateReconciledInvokeCount = 0;
+    bool mWarmStartFlag = false;
 };
 
 } /* namespace test */

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -83,6 +83,9 @@ public:
     void initLinkProberActiveStandby(std::shared_ptr<link_manager::ActiveStandbyStateMachine> linkManagerStateMachine);
     void generateServerMac(const std::string &portName, std::array<uint8_t, ETHER_ADDR_LEN> &address);
     void createPort(std::string port, common::MuxPortConfig::PortCableType portCableType = common::MuxPortConfig::PortCableType::ActiveStandby);
+    void warmRestartReconciliation(const std::string &portName);
+    void updatePortReconciliationCount(int increment);
+    void startWarmRestartReconciliationTimer(uint32_t timeout);
 
 public:
     static const std::string PortName;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to add support for linkmgrd process reconciliation after warm restart. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
One step of warm reboot procedure for dual ToR is to config the switch into `manual` mode. Before warm reboot finalizer executes `config save`, we want to config the switch back into `auto` mode, so `config_db.json` will be consistent before and after the reboot. 

#### How did you do it?
1. When linkmgrd is initializing, get the systemwide warm reboot flag from `WARM_RESTART_ENABLE_TABLE`. If flag == true, start a reconciliation timer. 
2. Maintenance a mux port count based on `MUX_CABLE|PORTNAME` count. When one port completes reconciliation, if warm restart flag == true, config it back into `auto` mode, reduce reconciliation port count by 1.
3. If reconciliation timer expires or port count == 0, set state to `reconciled` in `WARM_RESTART_TABLE|linkmgrd`.

#### How did you verify/test it?
1. Unit tests
2. Tested on dual ToR testbed. Ports were `auto` mode after warm restart completed. Entry `WARM_RESTART_TABLE|linkmgrd` was added as expected. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->