### PR TITLE
Avoid switching active when `LinkState == Down`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -715,7 +715,9 @@ void ActiveStandbyStateMachine::handlePeerLinkStateNotification(const link_state
     MUXLOGINFO(boost::format("%s: state db peer link state: %s") % mMuxPortConfig.getPortName() % mLinkStateName[label]);
 
     mPeerLinkState = label;
-    if(label == link_state::LinkState::Label::Down && ms(mCompositeState) == mux_state::MuxState::Standby) {
+    if(label == link_state::LinkState::Label::Down && 
+        ls(mCompositeState) == link_state::LinkState::Label::Up &&
+        ms(mCompositeState) == mux_state::MuxState::Standby) {
         CompositeState nextState = mCompositeState;
         enterLinkProberState(nextState, link_prober::LinkProberState::Wait);
         if (mDefaultRouteState == DefaultRoute::OK) {

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1095,6 +1095,21 @@ TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)
     VALIDATE_STATE(Active, Active, Up);
 }
 
+TEST_F(LinkManagerStateMachineTest, MuxStandbyLinkDownPeerLinkDown)
+{
+    setMuxStandby();
+
+    handleLinkState("down", 3);
+    VALIDATE_STATE(Standby, Standby, Down);
+
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+    postPeerLinkStateEvent("down", 3);
+
+    VALIDATE_STATE(Standby, Standby, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+}
+
+
 TEST_F(LinkManagerStateMachineTest, MuxActivePeerLinkStateUp)
 {
     setMuxActive();
@@ -1104,6 +1119,7 @@ TEST_F(LinkManagerStateMachineTest, MuxActivePeerLinkStateUp)
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
     VALIDATE_STATE(Active, Active, Up);
 }
+
 TEST_F(LinkManagerStateMachineTest, PostPckLossMetricsEvent) 
 {
     setMuxStandby();

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1109,7 +1109,6 @@ TEST_F(LinkManagerStateMachineTest, MuxStandbyLinkDownPeerLinkDown)
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
 }
 
-
 TEST_F(LinkManagerStateMachineTest, MuxActivePeerLinkStateUp)
 {
     setMuxActive();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address the mux flags when both sides are link down. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Every 60 sec xcvrd will update `MUX_CABLE_INFO|PORTNAME` table will peer's link state. If peer's down. self ToR was supposed to take over. If self and peer are both down, there will be two unnecessary toggles every minute. 

We want to avoid these toggles as it's meaning less for a link down ToR to switch to active.

#### How did you do it?
Check link state before switching to active when receiving a peer link down notification.

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->