### PR TITLE
Check self's mux mode before switching peer to standby & add support for `detach` mode

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -275,6 +275,10 @@ void MuxPort::handleMuxConfig(const std::string &config)
     } else if (config == "standby") {
         mode = common::MuxPortConfig::Standby;
     } else if (config == "detach") {
+        if (mMuxPortConfig.getPortCableType() ==  common::MuxPortConfig::PortCableType::ActiveStandby) {
+            MUXLOGWARNING(boost::format("port: %s, detach mode is only supported for acitve-active cable type")  % mMuxPortConfig.getPortName());
+            return;
+        }
         mode = common::MuxPortConfig::Detached;
     }
 

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -274,6 +274,8 @@ void MuxPort::handleMuxConfig(const std::string &config)
         mode = common::MuxPortConfig::Manual;
     } else if (config == "standby") {
         mode = common::MuxPortConfig::Standby;
+    } else if (config == "detach") {
+        mode = common::MuxPortConfig::Detached;
     }
 
     boost::asio::io_service &ioService = mStrand.context();

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -50,7 +50,8 @@ public:
         Auto,
         Manual,
         Active,
-        Standby
+        Standby,
+        Detached      // mux mode for active-active cable type only 
     };
 
     /**

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -695,7 +695,8 @@ void ActiveActiveStateMachine::switchMuxState(
     mux_state::MuxState::Label label
 )
 {
-    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
+        mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached) {
         MUXLOGWARNING(
             boost::format("%s: Switching MUX state to '%s'") %
             mMuxPortConfig.getPortName() %

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -722,14 +722,16 @@ void ActiveActiveStateMachine::switchMuxState(
 //
 void ActiveActiveStateMachine::switchPeerMuxState(mux_state::MuxState::Label label)
 {
-    MUXLOGWARNING(
-        boost::format("%s: Switching peer MUX state to '%s'") %
-        mMuxPortConfig.getPortName() %
-        mMuxStateName[label]
-    );
-    enterPeerMuxState(label);
-    mMuxPortPtr->setPeerMuxState(label);
-    startPeerMuxWaitTimer();
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
+        MUXLOGWARNING(
+            boost::format("%s: Switching peer MUX state to '%s'") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[label]
+        );
+        enterPeerMuxState(label);
+        mMuxPortPtr->setPeerMuxState(label);
+        startPeerMuxWaitTimer();
+    }
 }
 
 //

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -355,6 +355,20 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerUnknown)
     VALIDATE_PEER_STATE(PeerUnknown, Standby);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigDetachedLinkProberPeerUnknown)
+{
+    setMuxActive();
+   
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerActive);
+    VALIDATE_PEER_STATE(PeerActive, Active);
+
+    handleMuxConfig("detach", 1);
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerUnknown, 3);
+
+    VALIDATE_PEER_STATE(PeerUnknown, Active);
+    EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 0);
+}
+
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandby)
 {
     setMuxStandby();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Make sure self ToR is in `auto` mode before switching peer to `standby`. Also add support for `detach` mode. 

`detach` mode is equal to `auto` mode for SELF, but under this mode, ToR won't touch PEER's status. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->