### PR TITLE
Degrade `LinkProberStateMachineBase` virtual function logging level

### DIFF
--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -167,7 +167,7 @@ void LinkProberStateMachineBase::processEvent<IcmpUnknownEvent&>(IcmpUnknownEven
 //
 void LinkProberStateMachineBase::processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -177,7 +177,7 @@ void LinkProberStateMachineBase::processEvent(SuspendTimerExpiredEvent &suspendT
 //
 void LinkProberStateMachineBase::processEvent(IcmpPeerActiveEvent &icmpPeerActiveEvent)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -187,7 +187,7 @@ void LinkProberStateMachineBase::processEvent(IcmpPeerActiveEvent &icmpPeerActiv
 //
 void LinkProberStateMachineBase::processEvent(IcmpPeerUnknownEvent &icmpPeerUnknownEvent)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -197,7 +197,7 @@ void LinkProberStateMachineBase::processEvent(IcmpPeerUnknownEvent &icmpPeerUnkn
 //
 void LinkProberStateMachineBase::processEvent(SwitchActiveCommandCompleteEvent &switchActiveCommandCompleteEvent)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -207,7 +207,7 @@ void LinkProberStateMachineBase::processEvent(SwitchActiveCommandCompleteEvent &
 //
 void LinkProberStateMachineBase::processEvent(SwitchActiveRequestEvent &switchActiveRequestEvent)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -217,7 +217,7 @@ void LinkProberStateMachineBase::processEvent(SwitchActiveRequestEvent &switchAc
 //
 void LinkProberStateMachineBase::handleMackAddressUpdate(const std::array<uint8_t, ETHER_ADDR_LEN> address)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -227,7 +227,7 @@ void LinkProberStateMachineBase::handleMackAddressUpdate(const std::array<uint8_
 //
 void LinkProberStateMachineBase::handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //
@@ -237,7 +237,7 @@ void LinkProberStateMachineBase::handlePckLossRatioUpdate(const uint64_t unknown
 //
 LinkProberState *LinkProberStateMachineBase::getCurrentPeerState()
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
     return nullptr;
 }
 
@@ -248,7 +248,7 @@ LinkProberState *LinkProberStateMachineBase::getCurrentPeerState()
 //
 void LinkProberStateMachineBase::enterPeerState(LinkProberState::Label label)
 {
-    MUXLOGERROR(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
 
 //


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
If calling `LinkProberStateMachineBase` virtual functions, there are error logs in syslog:
```
[2022-05-26 09:13:17.210129] [error] link_prober/LinkProberStateMachineBase.cpp:230 handlePckLossRatioUpdate: Ethernet8
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Degrade the logging level to `DEBUG`

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->