### PR TITLE
Revert "Update log level for mux probing and mux state chance (#23)"

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -363,7 +363,7 @@ void DbInterface::handleSetPeerMuxState(const std::string portName, mux_state::M
 //
 void DbInterface::handleProbeMuxState(const std::string portName)
 {
-    MUXLOGWARNING(boost::format("%s: trigger xcvrd to read Mux State using i2c. ") % portName);
+    MUXLOGDEBUG(portName);
 
     mAppDbMuxCommandTablePtr->hset(portName, "command", "probe");
 }

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -483,7 +483,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
 void ActiveStandbyStateMachine::handleStateChange(MuxStateEvent &event, mux_state::MuxState::Label state)
 {
     if ((dynamic_cast<mux_state::MuxState *> (mMuxStateMachine.getCurrentState()))->getStateLabel() == state) {
-        MUXLOGWARNING(boost::format("%s: Received mux state event, new state: %s") %
+        MUXLOGINFO(boost::format("%s: Received mux state event, new state: %s") %
             mMuxPortConfig.getPortName() %
             mMuxStateName[state]
         );
@@ -616,7 +616,7 @@ void ActiveStandbyStateMachine::handleGetMuxStateNotification(mux_state::MuxStat
 //
 void ActiveStandbyStateMachine::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGWARNING(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    MUXLOGINFO(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mWaitTimer.cancel();
 


### PR DESCRIPTION
This reverts commit f38634c3c30dc99c6982defb40c441e89ef995fc.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Noticed that mux probing triggered by `LinkProberWaitMuxActive` or `LinkProberWaitMuxStandby` doesn't use the backoff factor, meaning every 300 ms there will be a mux state probing. It will cause unnecessary syslog. Revert PR#23 for now. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->