### PR TITLE
 Separate I2C mux state probing and gRPC forwarding state probing 

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -364,4 +364,23 @@ void MuxPort::resetPckLossCount()
     )));
 }
 
+//
+// ---> probeMuxState()
+//
+// trigger xcvrd to read MUX state using i2c
+//
+void MuxPort::probeMuxState()
+{
+    switch (mMuxPortConfig.getPortCableType()) {
+        case common::MuxPortConfig::PortCableType::ActiveActive:
+            mDbInterfacePtr->probeForwardingState(mMuxPortConfig.getPortName());
+            break;
+        case common::MuxPortConfig::PortCableType::ActiveStandby:
+            mDbInterfacePtr->probeMuxState(mMuxPortConfig.getPortName());
+            break;
+        default:
+            break;
+    }
+}
+
 } /* namespace mux */

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -145,7 +145,7 @@ public:
     *
     *@return label of MUX state
     */
-    inline void probeMuxState() {mDbInterfacePtr->probeMuxState(mMuxPortConfig.getPortName());};
+    inline void probeMuxState();
 
     /**
     *@method setMuxLinkmgrState

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -145,7 +145,7 @@ public:
     *
     *@return label of MUX state
     */
-    inline void probeMuxState();
+    void probeMuxState();
 
     /**
     *@method setMuxLinkmgrState

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -60,6 +60,11 @@ void FakeDbInterface::probeMuxState(const std::string &portName)
     mProbeMuxStateInvokeCount++;
 }
 
+void FakeDbInterface::probeForwardingState(const std::string &portName)
+{
+    mProbeForwardingStateInvokeCount++;
+}
+
 void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label)
 {
     mSetMuxLinkmgrStateInvokeCount++;

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -40,6 +40,7 @@ public:
     virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
     virtual void getMuxState(const std::string &portName) override;
     virtual void probeMuxState(const std::string &portName) override;
+    virtual void probeForwardingState(const std::string &portName) override;
     virtual void setMuxLinkmgrState(
         const std::string &portName,
         link_manager::ActiveStandbyStateMachine::Label label
@@ -75,6 +76,7 @@ public:
     uint32_t mSetPeerMuxStateInvokeCount = 0;
     uint32_t mGetMuxStateInvokeCount = 0;
     uint32_t mProbeMuxStateInvokeCount = 0;
+    uint32_t mProbeForwardingStateInvokeCount = 0;
     uint32_t mSetMuxLinkmgrStateInvokeCount = 0;
     uint32_t mPostMetricsInvokeCount = 0;
     uint32_t mPostLinkProberMetricsInvokeCount = 0;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to separate I2C mux state probing and gRPC forwarding state probing. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Current implementation used the same APP DB table for active-active port forwarding state probing and active-standby port mux state probing. This is breaking CLI tests in pre-test.

#### How did you do it?
1. use tables below for active-active port forwarding state probing. 
```
#define APP_FORWARDING_STATE_COMMAND_TABLE_NAME  "FORWARDING_STATE_COMMAND"
#define APP_FORWARDING_STATE_RESPONSE_TABLE_NAME "FORWARDING_STATE_RESPONSE"
```
2. `RESPONSE` table expects forwarding state response for both SELF and PEER. 
3. Rename some table names & handler functions to avoid confusion. 

#### How did you verify/test it?
Unit tests.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->