### PR TITLE
Fix IP header checksum in handleSendSwitchCommand

### DIFF
--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -450,7 +450,34 @@ private:
     *@return the appended TLV size
     */
     size_t appendTlvDummy(size_t paddingSize, int seqNo);
-    
+
+    /**
+     * @method initTlvSendSwitch
+     * 
+     * @brief initialize TX buffer TLVs to send switch command to peer
+     * 
+     * @return none
+     */
+    void initTxBufferTlvSendSwitch();
+
+    /**
+     * @method initTxBufferTlvSentinel
+     * 
+     * @brief initialize TX buffer to have only TLV sentinel
+     * 
+     * @return none
+     */
+    void initTxBufferTlvSentinel();
+
+    /**
+     * @method calculateChecksum
+     * 
+     * @brief calculate TX packet checksums in both IP header and ICMP header
+     * 
+     * @return none
+     */
+    inline void calculateTxPacketChecksum();
+
     /**
      * @method getProbingInterval
      * 

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -128,6 +128,26 @@ TEST_F(LinkProberTest, CalculateChecksum)
     EXPECT_TRUE(icmpHeader->checksum == 12100);
 }
 
+TEST_F(LinkProberTest, handleSendSwitchCommand)
+{
+    initializeSendBuffer();
+
+    iphdr *ipHeader = reinterpret_cast<iphdr *>(getTxBufferData() + sizeof(ether_header));
+    icmphdr *icmpHeader = reinterpret_cast<icmphdr *>(getTxBufferData() + sizeof(ether_header) + sizeof(iphdr));
+    ipHeader->id = static_cast<uint16_t> (17767);
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+
+    initTxBufferTlvSendSwitch();
+    EXPECT_TRUE(ipHeader->check == 61895);
+    EXPECT_TRUE(icmpHeader->checksum == 11838);
+
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+}
+
 TEST_F(LinkProberTest, UpdateEthernetFrame)
 {
     link_prober::IcmpPayload *icmpPayload = new (
@@ -288,26 +308,6 @@ TEST_F(LinkProberTest, ReadWriteVariableSizedTlv)
     }
 
     EXPECT_TRUE(findNextTlv(rxReadOffset, bytesTransferred) == 0);
-}
-
-TEST_F(LinkProberTest, handleSendSwitchCommand)
-{
-    initializeSendBuffer();
-
-    iphdr *ipHeader = reinterpret_cast<iphdr *>(getTxBufferData() + sizeof(ether_header));
-    icmphdr *icmpHeader = reinterpret_cast<icmphdr *>(getTxBufferData() + sizeof(ether_header) + sizeof(iphdr));
-    ipHeader->id = static_cast<uint16_t> (17767);
-    initTxBufferSentinel();
-    EXPECT_TRUE(ipHeader->check == 62919);
-    EXPECT_TRUE(icmpHeader->checksum == 12100);
-
-    initTxBufferTlvSendSwitch();
-    EXPECT_TRUE(ipHeader->check == 61895);
-    EXPECT_TRUE(icmpHeader->checksum == 11838);
-
-    initTxBufferSentinel();
-    EXPECT_TRUE(ipHeader->check == 62919);
-    EXPECT_TRUE(icmpHeader->checksum == 12100);
 }
 
 TEST_F(LinkProberTest, InitializeException)

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -290,6 +290,26 @@ TEST_F(LinkProberTest, ReadWriteVariableSizedTlv)
     EXPECT_TRUE(findNextTlv(rxReadOffset, bytesTransferred) == 0);
 }
 
+TEST_F(LinkProberTest, handleSendSwitchCommand)
+{
+    initializeSendBuffer();
+
+    iphdr *ipHeader = reinterpret_cast<iphdr *>(getTxBufferData() + sizeof(ether_header));
+    icmphdr *icmpHeader = reinterpret_cast<icmphdr *>(getTxBufferData() + sizeof(ether_header) + sizeof(iphdr));
+    ipHeader->id = static_cast<uint16_t> (17767);
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+
+    initTxBufferTlvSendSwitch();
+    EXPECT_TRUE(ipHeader->check == 61895);
+    EXPECT_TRUE(icmpHeader->checksum == 11838);
+
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+}
+
 TEST_F(LinkProberTest, InitializeException)
 {
     EXPECT_THROW(initialize(), common::SocketErrorException);

--- a/test/LinkProberTest.h
+++ b/test/LinkProberTest.h
@@ -57,6 +57,8 @@ public:
     uint16_t getRxSelfSeqNo() {return mLinkProber.mRxSelfSeqNo;};
     uint16_t getRxPeerSeqNo() {return mLinkProber.mRxPeerSeqNo;};
     bool getSuspendTx() {return mLinkProber.mSuspendTx;};
+    void initTxBufferTlvSendSwitch() {mLinkProber.initTxBufferTlvSendSwitch();}
+    void initTxBufferSentinel() {mLinkProber.initTxBufferTlvSentinel();}
 
     boost::asio::io_service mIoService;
     common::MuxConfig mMuxConfig;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the IP header checksum error in the packet sent by `handleSendSwitchCommand`

Signed-off-by: 
Longxiang Lyu <lolv@microsoft.com> 
Jing Zhang zhangjing@microsoft.com 

#### How did you do it?
Update IP header checksum after appending `TlvCommand`.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->