### PR TITLE
Remove exception throwing when initializing missing loopback interface

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -516,7 +516,7 @@ void DbInterface::processTorMacAddress(std::string& mac)
         mMuxManagerPtr->setTorMacAddress(macAddress);
     }
     catch (const std::invalid_argument &invalidArgument) {
-        MUXLOGFATAL("Config Not Found: Invalid ToR MAC address" + mac);
+        throw MUX_ERROR(ConfigNotFound, "Invalid ToR MAC address " + mac);
     }
 }
 
@@ -537,7 +537,7 @@ void DbInterface::getTorMacAddress(std::shared_ptr<swss::DBConnector> configDbCo
     if (configDbMetadataTable.hget(localhost, key, mac)) {
         processTorMacAddress(mac);
     } else {
-        MUXLOGFATAL("Config Not Found: ToR MAC address is not found");
+        throw MUX_ERROR(ConfigNotFound, "ToR MAC address is not found");
     }
 }
 

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -516,7 +516,7 @@ void DbInterface::processTorMacAddress(std::string& mac)
         mMuxManagerPtr->setTorMacAddress(macAddress);
     }
     catch (const std::invalid_argument &invalidArgument) {
-        throw MUX_ERROR(ConfigNotFound, "Invalid ToR MAC address " + mac);
+        MUXLOGFATAL("Config Not Found: Invalid ToR MAC address" + mac);
     }
 }
 
@@ -537,7 +537,7 @@ void DbInterface::getTorMacAddress(std::shared_ptr<swss::DBConnector> configDbCo
     if (configDbMetadataTable.hget(localhost, key, mac)) {
         processTorMacAddress(mac);
     } else {
-        throw MUX_ERROR(ConfigNotFound, "ToR MAC address is not found");
+        MUXLOGFATAL("Config Not Found: ToR MAC address is not found");
     }
 }
 
@@ -577,7 +577,7 @@ void DbInterface::processLoopback2InterfaceInfo(std::vector<std::string> &loopba
     }
 
     if (!loopback2IPv4Found) {
-        throw MUX_ERROR(ConfigNotFound, "Loopback2 IPv4 address missing");
+        MUXLOGFATAL(boost::format("Config not found: Loopback2 IPv4 address missing, using default value %s ") % mMuxManagerPtr->getLoopbackIpv4Address().to_string());
     }
 }
 

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -194,6 +194,15 @@ public:
     void setUseWellKnownMacActiveActive(bool useWellKnownMac);
 
     /**
+     * @method getLoopbackIpv4Address
+     * 
+     * @brief getter for loop back ipv4 address 
+     * 
+     * @return IPv4 address
+     */
+    inline boost::asio::ip::address getLoopbackIpv4Address() {return mMuxConfig.getLoopbackIpv4Address();};
+
+    /**
     *@method initialize
     *
     *@brief initialize MuxManager class and creates DbInterface instance that reads/listen from/to Redis db

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -440,6 +440,7 @@ TEST_F(MuxManagerTest, Loopback2Address)
     processLoopback2InterfaceInfo(loopbackIntfs);
 
     EXPECT_TRUE(getLoopbackIpv4Address(port).to_string() == ipAddress);
+    EXPECT_TRUE(mMuxManagerPtr->getLoopbackIpv4Address() == getLoopbackIpv4Address(port));
 }
 
 TEST_F(MuxManagerTest, Loopback2AddressException)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -448,13 +448,14 @@ TEST_F(MuxManagerTest, Loopback2AddressException)
 
     createPort(port);
 
+    std::string defaultAddress = "10.212.64.0";
     std::vector<std::string> loopbackIntfs = {
         "Loopback2|2603:10e1:100:d::1/128",
         "Loopback2|250.260.270.280/32",
         "Loopback2"
     };
 
-    EXPECT_THROW(processLoopback2InterfaceInfo(loopbackIntfs), common::ConfigNotFoundException);
+    EXPECT_TRUE(getLoopbackIpv4Address(port).to_string() == defaultAddress);
 }
 
 TEST_F(MuxManagerTest, ToRMacAddress)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to avoid throwing exception when linkmgrd initializing without CONFIG DB loopback interface entry. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->
- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Avoid unnecessary process exits. 

#### How did you do it?
Log a fatal message instead of exiting the process. 

#### How did you verify/test it?
Tested on dual testbeds. Met all expected behavior below:
1. Remove loopback interface live (when linkmgrd is running):   
    No linkmgrd crash. `show mux status` reported `unhealthy` as no IP interface to receive heartbeat packets.
2. Start mux service when missing loopback interface:  
    No linkmgrd crash. Saw fatal log below in syslog. `show mux status` report `unhealthy`.
3. Add back loopback interface CONFIG DB entry live:  
    `show mux status` reported `healthy`.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->