### PR TITLE
Enforce another toggle after config mux to active first toggle failed

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -150,15 +150,15 @@ public: // db event handlers
 
     /**
      * @method handleDefaultRouteStateNotification(const DefaultRoute routeState)
-     * 
+     *
      * @brief handle default route state notification from routeorch
-     * 
+     *
      * @param routeState
-     * 
+     *
      * @return none
-    */
+     */
     void handleDefaultRouteStateNotification(const DefaultRoute routeState) override;
-    
+
     /**
      *@method handleGetServerMacNotification
      *
@@ -273,6 +273,15 @@ public: // state transition functions
     void LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState);
 
     /**
+     * @method LinkProberUnknownMuxStandbyLinkUpTransitionFunction
+     *
+     * @brief transition function when entering {LinkProberUnknown, MuxStandby, LinkUp} state
+     *
+     * @param nextState                     reference to composite state
+     */
+    void LinkProberUnknownMuxStandbyLinkUpTransitionFunction(CompositeState &nextState);
+
+    /**
      * @method LinkProberUnknownMuxUnknownLinkUpTransitionFunction
      *
      * @brief transition function when entering {LinkProberUnknown, MuxUnknown, LinkUp} state
@@ -374,8 +383,9 @@ private: // utility methods to check/modify state
      *
      * @param nextState                     reference to composite state
      * @param label                         new MuxState label to switch to
+     * @param forceSwitch                   force switch mux state, used to match the driver state only
      */
-    inline void switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label);
+    inline void switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label, bool forceSwitch = false);
 
     /**
      * @method switchPeerMuxState
@@ -467,9 +477,9 @@ private:
 
     /**
      * @method shutdownOrRestartLinkProberOnDefaultRoute()
-     * 
+     *
      * @brief  shutdown or restart link prober based on default route state
-     * 
+     *
      * @return none
      */
     void shutdownOrRestartLinkProberOnDefaultRoute() override;
@@ -558,6 +568,7 @@ private: // testing only
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
+    mux_state::MuxState::Label mLastMuxStateNotification = mux_state::MuxState::Label::Unknown;
 
 private:
     uint32_t mMuxProbeBackoffFactor = 1;

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -496,4 +496,76 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceHeartBeatF
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigActiveProbeActive)
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleMuxConfig("active", 1);
+    VALIDATE_STATE(Unknown, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("unknown", 5);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleProbeMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    // xcvrd now answers the mux probe
+    handleProbeMuxState("active", 3);
+    VALIDATE_STATE(Unknown, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Unknown, Active, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigActiveProbeStandby)
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleMuxConfig("active", 1);
+    VALIDATE_STATE(Unknown, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("unknown", 5);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleProbeMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    // xcvrd now answers the mux probe
+    handleProbeMuxState("standby", 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Unknown, Active, Up);
+}
+
 } /* namespace test */


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
After `config mux state active EthernetXX`, the first toggle might not be able to be succeeded as `xcvrd` has a chance to fail to setup the gRPC connection as the route changed by `muxorch` needs time to work.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
The state change sequence after `linkmgrd` boots up and receives a mux config active:

(unknown, unknown, up) --> config mux active --> (unknown, active, up) --> mux state unknown[as xcvrd could not setup gRPC connection] --> (unknown, unknown, up) --> probe mux state, return unknown --> (unknown, unknown, up)

Once `linkmgrd` reaches (unknown, unknown, up), it will keep probing the mux till `xcvrd` returns either active or standby:
if the probe result is active, we need an extra toggle to active to let `show mux status` shows active.
if the probe result is standby, we also need an extra toggle to active to notify the gRPC server the port is standby and let `show mux status` shows active.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->