### PR TITLE
Avoid unnecessary error logs from `handleGetServerMacAddressNotification`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -299,7 +299,7 @@ void ActiveActiveStateMachine::handleGetServerMacAddressNotification(std::array<
         mMuxPortConfig.setBladeMacAddress(address);
         if (mUpdateEthernetFrameFnPtr) {
             mUpdateEthernetFrameFnPtr();
-        } else {
+        } else if (mComponentInitState.test(LinkProberComponent)) {
             std::array<char, 3 *ETHER_ADDR_LEN> addressStr = {0};
             snprintf(
                 addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -335,7 +335,7 @@ void ActiveActiveStateMachine::handleUseWellKnownMacAddressNotification()
 
     if (mUpdateEthernetFrameFnPtr) {
         mUpdateEthernetFrameFnPtr();
-    } else {
+    } else if (mComponentInitState.test(LinkProberComponent)) {
         std::array<char, 3 *ETHER_ADDR_LEN> addressStr = {0};
         snprintf(
             addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -572,7 +572,7 @@ void ActiveStandbyStateMachine::handleGetServerMacAddressNotification(std::array
         mMuxPortConfig.setBladeMacAddress(address);
         if (mUpdateEthernetFrameFnPtr) {
             mUpdateEthernetFrameFnPtr();
-        } else {
+        } else if (mComponentInitState.test(LinkProberComponent)) {
             std::array<char, 3 * ETHER_ADDR_LEN> addressStr = {0};
             snprintf(
                 addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -56,6 +56,7 @@ public:
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
     bool getIfUseWellKnownMac(std::string port);
+    bool setUseWellKnownMacActiveActive(bool use);
     bool getIfUseToRMac(std::string port);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -86,6 +86,7 @@ public:
     void warmRestartReconciliation(const std::string &portName);
     void updatePortReconciliationCount(int increment);
     void startWarmRestartReconciliationTimer(uint32_t timeout);
+    void resetUpdateEthernetFrameFn(const std::string &portName);
 
 public:
     static const std::string PortName;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
If blade MAC address is processed before link prober's initialization, we will expect to see the error message below. 

```
Jun  2 09:13:37.094025 str2-7260cx3-acs-13 ERR mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:640 handleGetServerMacAddressNotification: Ethernet96: failed to update Ethernet frame with mac ......
``` 

Since link prober is not initialized, of course there was no Ethernet frame to update. The blade mac will still be stored in mux port config object and will be consumed later when link prober is activated. This shouldn't be considered as an error. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid unnecessary error message, so tests won't fail for log analyzer. 

#### How did you do it?
Check if link prober is initialized before logging the error message. 

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->